### PR TITLE
Apply fixes from `cargo check`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,8 +157,10 @@ dependencies = [
  "automod",
  "cargo-test-macro",
  "cargo-test-support",
+ "cargo-util",
  "clap",
  "clap-cargo",
+ "indexmap",
  "rustfix",
  "serde",
  "serde_json",
@@ -901,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,8 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 rustfix = "0.9.0"
 serde = { version = "1.0.219", features = ["derive"]}
 serde_json = "1.0.140"
+cargo-util = "0.2.20"
+indexmap = "2.9.0"
 
 [dev-dependencies]
 automod = "1.0.14"

--- a/src/bin/cargo-fixit/fixit.rs
+++ b/src/bin/cargo-fixit/fixit.rs
@@ -1,12 +1,16 @@
 use std::{
+    collections::HashSet,
     io::{BufRead, BufReader},
     process::Stdio,
 };
 
 use cargo_fixit::CargoResult;
+use cargo_util::paths;
 use clap::Parser;
-use rustfix::diagnostics::Diagnostic;
+use indexmap::{IndexMap, IndexSet};
+use rustfix::{collect_suggestions, diagnostics::Diagnostic, CodeFix};
 use serde::Deserialize;
+use tracing::{trace, warn};
 
 #[derive(Debug, Parser)]
 pub(crate) struct FixitArgs {
@@ -27,6 +31,11 @@ struct CheckMessage {
 }
 
 fn exec(_args: FixitArgs) -> CargoResult<()> {
+    let only = HashSet::new();
+    let mut file_map = IndexMap::new();
+
+    let mut errors = IndexSet::new();
+
     let mut command = std::process::Command::new(env!("CARGO"))
         .args(["check", "--message-format", "json"])
         .stderr(Stdio::piped())
@@ -41,12 +50,85 @@ fn exec(_args: FixitArgs) -> CargoResult<()> {
             _ => continue,
         };
 
-        if let Some(rendered) = diagnostic.rendered {
-            eprint!("{rendered}");
+        let Some(suggestion) =
+            collect_suggestions(&diagnostic, &only, rustfix::Filter::MachineApplicableOnly)
+        else {
+            trace!("rejecting as not a MachineApplicable diagnosis: {diagnostic:?}");
+            if let Some(rendered) = diagnostic.rendered {
+                errors.insert(rendered);
+            }
+            continue;
+        };
+
+        let file_names = suggestion
+            .solutions
+            .iter()
+            .flat_map(|s| s.replacements.iter())
+            .map(|r| &r.snippet.file_name);
+
+        let file_name = if let Some(file_name) = file_names.clone().next() {
+            file_name.clone()
+        } else {
+            trace!("rejecting as it has no solutions {:?}", suggestion);
+            if let Some(rendered) = diagnostic.rendered {
+                errors.insert(rendered);
+            }
+            continue;
+        };
+
+        if !file_names.clone().all(|f| f == &file_name) {
+            trace!("rejecting as it changes multiple files: {:?}", suggestion);
+            if let Some(rendered) = diagnostic.rendered {
+                errors.insert(rendered);
+            }
+            continue;
         }
+
+        file_map
+            .entry(file_name)
+            .or_insert_with(IndexSet::new)
+            .insert((suggestion, diagnostic.rendered));
     }
 
     let _exit_code = command.wait()?;
+
+    for (file, suggestions) in file_map {
+        let code = match paths::read(file.as_ref()) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("failed to read `{}`: {}", file, e);
+                errors.extend(suggestions.iter().filter_map(|(_, e)| e.clone()));
+                continue;
+            }
+        };
+
+        let mut fixed = CodeFix::new(&code);
+        let mut num_fixes = 0;
+
+        for (suggestion, rendered) in suggestions {
+            match fixed.apply(&suggestion) {
+                Ok(()) => num_fixes += 1,
+                Err(rustfix::Error::AlreadyReplaced {
+                    is_identical: true, ..
+                }) => {}
+                Err(e) => {
+                    if let Some(rendered) = rendered {
+                        errors.insert(rendered);
+                    }
+                    warn!("{e:?}");
+                }
+            }
+        }
+        if fixed.modified() {
+            eprintln!("{file}: {num_fixes} fixes");
+            let new_code = fixed.finish()?;
+            paths::write(&file, new_code)?;
+        }
+    }
+
+    for e in errors {
+        eprint!("{e}");
+    }
 
     Ok(())
 }

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -21,16 +21,7 @@ fn basic() {
     p.cargo_("fixit")
         .with_status(0)
         .with_stderr_data(str![[r#"
-[WARNING] variable does not need to be mutable
- --> src/lib.rs:3:21
-  |
-3 |                 let mut b = 10;
-  |                     ----^
-  |                     |
-  |                     [HELP] remove this `mut`
-  |
-  = [NOTE] `#[warn(unused_mut)]` on by default
-
+src/lib.rs: 1 fixes
 
 "#]])
         .run();
@@ -39,7 +30,7 @@ fn basic() {
         str![[r#"
 
             pub fn a() {
-                let mut b = 10;
+                let b = 10;
                 let _ = b;
             }
             
@@ -66,6 +57,7 @@ fn fixable_and_unfixable() {
     p.cargo_("fixit")
         .with_status(0)
         .with_stderr_data(str![[r#"
+src/lib.rs: 1 fixes
 [WARNING] unused variable: `c`
  --> src/lib.rs:6:21
   |
@@ -73,16 +65,6 @@ fn fixable_and_unfixable() {
   |                     ^ [HELP] if this is intentional, prefix it with an underscore: `_c`
   |
   = [NOTE] `#[warn(unused_variables)]` on by default
-
-[WARNING] variable does not need to be mutable
- --> src/lib.rs:3:21
-  |
-3 |                 let mut b = 10;
-  |                     ----^
-  |                     |
-  |                     [HELP] remove this `mut`
-  |
-  = [NOTE] `#[warn(unused_mut)]` on by default
 
 
 "#]])
@@ -92,7 +74,7 @@ fn fixable_and_unfixable() {
         str![[r#"
 
             pub fn a() {
-                let mut b = 10;
+                let b = 10;
                 let _ = b;
 
                 let c = 10;

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -46,3 +46,58 @@ fn basic() {
 "#]],
     );
 }
+
+#[cargo_test]
+fn fixable_and_unfixable() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+            pub fn a() {
+                let mut b = 10;
+                let _ = b;
+
+                let c = 10;
+            }
+            "#,
+        )
+        .build();
+
+    p.cargo_("fixit")
+        .with_status(0)
+        .with_stderr_data(str![[r#"
+[WARNING] unused variable: `c`
+ --> src/lib.rs:6:21
+  |
+6 |                 let c = 10;
+  |                     ^ [HELP] if this is intentional, prefix it with an underscore: `_c`
+  |
+  = [NOTE] `#[warn(unused_variables)]` on by default
+
+[WARNING] variable does not need to be mutable
+ --> src/lib.rs:3:21
+  |
+3 |                 let mut b = 10;
+  |                     ----^
+  |                     |
+  |                     [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` on by default
+
+
+"#]])
+        .run();
+    assert_ui().eq(
+        p.read_file("src/lib.rs"),
+        str![[r#"
+
+            pub fn a() {
+                let mut b = 10;
+                let _ = b;
+
+                let c = 10;
+            }
+            
+"#]],
+    );
+}


### PR DESCRIPTION
Fixes fixable errors once and outputs the remaining errors

Fixes https://github.com/crate-ci/cargo-fixit/issues/11