### PR TITLE
feat: Allow fixing clippy lints

### DIFF
--- a/src/bin/cargo-fixit/fixit.rs
+++ b/src/bin/cargo-fixit/fixit.rs
@@ -20,6 +20,10 @@ pub(crate) struct FixitArgs {
     #[arg(long)]
     allow_no_vcs: bool,
 
+    /// Run `clippy` instead of `check`
+    #[arg(long)]
+    clippy: bool,
+
     #[command(flatten)]
     check_flags: CheckFlags,
 }
@@ -101,8 +105,9 @@ fn run_rustfix(
 
     let mut errors = IndexSet::new();
 
+    let cmd = if args.clippy { "clippy" } else { "check" };
     let mut command = std::process::Command::new(env!("CARGO"))
-        .args(["check", "--message-format", "json"])
+        .args([cmd, "--message-format", "json"])
         .args(args.check_flags.to_flags())
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())

--- a/tests/testsuite/help/stdout.term.svg
+++ b/tests/testsuite/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="614px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="632px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -28,59 +28,61 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>      --allow-no-vcs  Fix code even if a VCS was not detected</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  -Z &lt;FLAG&gt;           Unstable (nightly-only) flags</tspan>
+    <tspan x="10px" y="136px"><tspan>      --clippy        Run `clippy` instead of `check`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  -h, --help          Print help</tspan>
+    <tspan x="10px" y="154px"><tspan>  -Z &lt;FLAG&gt;           Unstable (nightly-only) flags</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  -V, --version       Print version</tspan>
+    <tspan x="10px" y="172px"><tspan>  -h, --help          Print help</tspan>
 </tspan>
-    <tspan x="10px" y="190px">
+    <tspan x="10px" y="190px"><tspan>  -V, --version       Print version</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>Package Selection:</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      --package &lt;SPEC&gt;  Package(s) to fix</tspan>
+    <tspan x="10px" y="226px"><tspan>Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
+    <tspan x="10px" y="244px"><tspan>      --package &lt;SPEC&gt;  Package(s) to fix</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
+    <tspan x="10px" y="262px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="280px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>Target Selection:</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      --lib             Fix only this package's library</tspan>
+    <tspan x="10px" y="334px"><tspan>Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      --bins            Fix all binaries</tspan>
+    <tspan x="10px" y="352px"><tspan>      --lib             Fix only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
+    <tspan x="10px" y="370px"><tspan>      --bins            Fix all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      --examples        Fix all examples</tspan>
+    <tspan x="10px" y="388px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
+    <tspan x="10px" y="406px"><tspan>      --examples        Fix all examples</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      --tests           Fix all tests</tspan>
+    <tspan x="10px" y="424px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
+    <tspan x="10px" y="442px"><tspan>      --tests           Fix all tests</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      --benches         Fix all benches</tspan>
+    <tspan x="10px" y="460px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
+    <tspan x="10px" y="478px"><tspan>      --benches         Fix all benches</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      --all-targets     Fix all targets</tspan>
+    <tspan x="10px" y="496px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
 </tspan>
-    <tspan x="10px" y="514px">
+    <tspan x="10px" y="514px"><tspan>      --all-targets     Fix all targets</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>Feature Selection:</tspan>
+    <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="550px"><tspan>Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      --all-features         Activate all available features</tspan>
+    <tspan x="10px" y="568px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="586px"><tspan>      --all-features         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
+</tspan>
+    <tspan x="10px" y="622px">
 </tspan>
   </text>
 


### PR DESCRIPTION
The `fix` machinery is most likely used on `--edition` and `cargo clippy --fix`.  By offering a hacky `--clippy` flag, we allow more users to experiment with this command.