### PR TITLE
 feat: Added `broken-code` flag 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
+        components: rust-src
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-hack

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -296,7 +296,7 @@ fn fix_errors(
 ) -> CargoResult<bool> {
     let mut made_changes = false;
     for (file, suggestions) in file_map {
-        let code = match paths::read(file.as_ref()) {
+        let source = match paths::read(file.as_ref()) {
             Ok(s) => s,
             Err(e) => {
                 warn!("failed to read `{}`: {}", file, e);
@@ -305,7 +305,7 @@ fn fix_errors(
             }
         };
 
-        let mut fixed = CodeFix::new(&code);
+        let mut fixed = CodeFix::new(&source);
         let mut num_fixes = 0;
 
         for (suggestion, rendered) in suggestions.iter().rev() {
@@ -323,8 +323,8 @@ fn fix_errors(
             }
         }
         if fixed.modified() {
-            let new_code = fixed.finish()?;
-            paths::write(&file, new_code)?;
+            let new_source = fixed.finish()?;
+            paths::write(&file, new_source)?;
             made_changes = true;
             files.entry(file).or_default().fixes += num_fixes;
         }

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -15,7 +15,10 @@ use tracing::{trace, warn};
 use crate::{
     core::shell,
     ops::check::{BuildUnit, CheckOutput, Message},
-    util::{cli::CheckFlags, package::format_package_id, vcs::VcsOpts},
+    util::{
+        cli::CheckFlags, messages::gen_please_report_this_bug_text, package::format_package_id,
+        vcs::VcsOpts,
+    },
     CargoResult,
 };
 
@@ -92,6 +95,8 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                     paths::write(file, original_source)?;
                 }
                 out.push('\n');
+
+                out.push_str(&gen_please_report_this_bug_text(args.clippy));
 
                 let mut errors = messages
                     .filter_map(|e| match e {

--- a/src/util/messages.rs
+++ b/src/util/messages.rs
@@ -1,0 +1,18 @@
+pub fn gen_please_report_this_bug_text(clippy: bool) -> String {
+    format!(
+        "This likely indicates a bug in either rustc or cargo itself,\n\
+     and we would appreciate a bug report! You're likely to see\n\
+     a number of compiler warnings after this message which cargo\n\
+     attempted to fix but failed. If you could open an issue at\n\
+     {}\n\
+     quoting the full output of this command we'd be very appreciative!\n\
+     Note that you may be able to make some more progress in the near-term\n\
+     fixing code with the `--broken-code` flag\n\n\
+     ",
+        if clippy {
+            "https://github.com/rust-lang/rust-clippy/issues"
+        } else {
+            "https://github.com/rust-lang/rust/issues"
+        }
+    )
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod cli;
+pub mod messages;
 pub mod package;
 pub mod vcs;

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2037,6 +2037,15 @@ after fixes were automatically applied the compiler reported errors within these
 
   * src/lib.rs
 
+This likely indicates a bug in either rustc or cargo itself,
+and we would appreciate a bug report! You're likely to see
+a number of compiler warnings after this message which cargo
+attempted to fix but failed. If you could open an issue at
+https://github.com/rust-lang/rust/issues
+quoting the full output of this command we'd be very appreciative!
+Note that you may be able to make some more progress in the near-term
+fixing code with the `--broken-code` flag
+
 The original errors are:
 [WARNING] unused variable: `x`
  --> src/lib.rs:3:29

--- a/tests/testsuite/fix_n_times.rs
+++ b/tests/testsuite/fix_n_times.rs
@@ -397,6 +397,15 @@ after fixes were automatically applied the compiler reported errors within these
 
   * src/lib.rs
 
+This likely indicates a bug in either rustc or cargo itself,
+and we would appreciate a bug report! You're likely to see
+a number of compiler warnings after this message which cargo
+attempted to fix but failed. If you could open an issue at
+https://github.com/rust-lang/rust/issues
+quoting the full output of this command we'd be very appreciative!
+Note that you may be able to make some more progress in the near-term
+fixing code with the `--broken-code` flag
+
 The errors reported are:
 rustc fix shim error count=2
 
@@ -427,6 +436,15 @@ fn fix_verification_failed_clippy() {
 after fixes were automatically applied the compiler reported errors within these files:
 
   * src/lib.rs
+
+This likely indicates a bug in either rustc or cargo itself,
+and we would appreciate a bug report! You're likely to see
+a number of compiler warnings after this message which cargo
+attempted to fix but failed. If you could open an issue at
+https://github.com/rust-lang/rust/issues
+quoting the full output of this command we'd be very appreciative!
+Note that you may be able to make some more progress in the near-term
+fixing code with the `--broken-code` flag
 
 The errors reported are:
 rustc fix shim error count=2

--- a/tests/testsuite/fix_n_times.rs
+++ b/tests/testsuite/fix_n_times.rs
@@ -387,17 +387,26 @@ fn fix_verification_failed() {
     // One suggested fix, with an error in the verification step.
     // This should cause `cargo fix` to back out the changes.
     expect_fix_runs_rustc_n_times(
-        &[Step::OneFix, Step::Error, Step::SuccessNoOutput],
+        &[Step::OneFix, Step::Error],
         |_execs| {},
         str![[r#"
-[CHECKING] foo v0.0.1
-[FIXED] src/lib.rs (1 fix)
+[NOTE] reverting `src/lib.rs` to its original state
+[WARNING] failed to automatically apply fixes suggested by rustc
+
+after fixes were automatically applied the compiler reported errors within these files:
+
+  * src/lib.rs
+
+The errors reported are:
 rustc fix shim error count=2
 
 
+[NOTE] try using `--broken-code` to fix errors
+[ERROR] could not compile
+
 "#]],
-        "// fix-count 1",
-        0,
+        "// fix-count 0",
+        1,
     );
 }
 
@@ -407,19 +416,28 @@ fn fix_verification_failed_clippy() {
     // the error message has the customization for the clippy URL and
     // subcommand.
     expect_fix_runs_rustc_n_times(
-        &[Step::OneFix, Step::Error, Step::SuccessNoOutput],
+        &[Step::OneFix, Step::Error],
         |execs| {
             execs.env("RUSTC_WORKSPACE_WRAPPER", wrapped_clippy_driver());
         },
         str![[r#"
-[CHECKING] foo v0.0.1
-[FIXED] src/lib.rs (1 fix)
+[NOTE] reverting `src/lib.rs` to its original state
+[WARNING] failed to automatically apply fixes suggested by rustc
+
+after fixes were automatically applied the compiler reported errors within these files:
+
+  * src/lib.rs
+
+The errors reported are:
 rustc fix shim error count=2
 
 
+[NOTE] try using `--broken-code` to fix errors
+[ERROR] could not compile
+
 "#]],
-        "// fix-count 1",
-        0,
+        "// fix-count 0",
+        1,
     );
 }
 
@@ -447,13 +465,14 @@ fn starts_with_error() {
         &[Step::Error],
         |_execs| {},
         str![[r#"
-[CHECKING] foo v0.0.1
 rustc fix shim error count=1
 
+[NOTE] try using `--broken-code` to fix errors
+[ERROR] could not compile
 
 "#]],
         "// fix-count 0",
-        0,
+        1,
     );
 }
 
@@ -466,17 +485,13 @@ fn broken_code_no_suggestions() {
             execs.arg("--broken-code");
         },
         str![[r#"
-[ERROR] unexpected argument '--broken-code' found
+[CHECKING] foo v0.0.1
+rustc fix shim error count=1
 
-  tip: a similar argument exists: '--bench'
-
-Usage: cargo fixit --allow-no-vcs --lib --bench <NAME>
-
-For more information, try '--help'.
 
 "#]],
         "// fix-count 0",
-        2,
+        0,
     );
 }
 
@@ -484,21 +499,18 @@ For more information, try '--help'.
 fn broken_code_one_suggestion() {
     // --broken-code where there is an error and a suggestion.
     expect_fix_runs_rustc_n_times(
-        &[Step::OneFixError, Step::Error],
+        &[Step::OneFixError, Step::Error, Step::SuccessNoOutput],
         |execs| {
             execs.arg("--broken-code");
         },
         str![[r#"
-[ERROR] unexpected argument '--broken-code' found
+[CHECKING] foo v0.0.1
+[FIXED] src/lib.rs (1 fix)
+rustc fix shim error count=2
 
-  tip: a similar argument exists: '--bench'
-
-Usage: cargo fixit --allow-no-vcs --lib --bench <NAME>
-
-For more information, try '--help'.
 
 "#]],
         "// fix-count 1",
-        2,
+        0,
     );
 }

--- a/tests/testsuite/help/stdout.term.svg
+++ b/tests/testsuite/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="785px" height="668px" xmlns="http://www.w3.org/2000/svg">
+<svg width="785px" height="686px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -28,65 +28,67 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>      --clippy        Run `clippy` instead of `check`</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      --allow-no-vcs  Fix code even if a VCS was not detected</tspan>
+    <tspan x="10px" y="136px"><tspan>      --broken-code   Fix code even if it already has compiler errors</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      --allow-dirty   Fix code even if the working directory is dirty or has staged changes</tspan>
+    <tspan x="10px" y="154px"><tspan>      --allow-no-vcs  Fix code even if a VCS was not detected</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --allow-staged  Fix code even if the working directory has staged changes</tspan>
+    <tspan x="10px" y="172px"><tspan>      --allow-dirty   Fix code even if the working directory is dirty or has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  -Z &lt;FLAG&gt;           Unstable (nightly-only) flags</tspan>
+    <tspan x="10px" y="190px"><tspan>      --allow-staged  Fix code even if the working directory has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -h, --help          Print help</tspan>
+    <tspan x="10px" y="208px"><tspan>  -Z &lt;FLAG&gt;           Unstable (nightly-only) flags</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -V, --version       Print version</tspan>
+    <tspan x="10px" y="226px"><tspan>  -h, --help          Print help</tspan>
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan>  -V, --version       Print version</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>Package Selection:</tspan>
+    <tspan x="10px" y="262px">
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      --package &lt;SPEC&gt;  Package(s) to fix</tspan>
+    <tspan x="10px" y="280px"><tspan>Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
+    <tspan x="10px" y="298px"><tspan>      --package &lt;SPEC&gt;  Package(s) to fix</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
+    <tspan x="10px" y="316px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="334px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
 </tspan>
-    <tspan x="10px" y="352px">
+    <tspan x="10px" y="352px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>Target Selection:</tspan>
+    <tspan x="10px" y="370px">
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      --lib             Fix only this package's library</tspan>
+    <tspan x="10px" y="388px"><tspan>Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      --bins            Fix all binaries</tspan>
+    <tspan x="10px" y="406px"><tspan>      --lib             Fix only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
+    <tspan x="10px" y="424px"><tspan>      --bins            Fix all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      --examples        Fix all examples</tspan>
+    <tspan x="10px" y="442px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
+    <tspan x="10px" y="460px"><tspan>      --examples        Fix all examples</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      --tests           Fix all tests</tspan>
+    <tspan x="10px" y="478px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
+    <tspan x="10px" y="496px"><tspan>      --tests           Fix all tests</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      --benches         Fix all benches</tspan>
+    <tspan x="10px" y="514px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
+    <tspan x="10px" y="532px"><tspan>      --benches         Fix all benches</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      --all-targets     Fix all targets</tspan>
+    <tspan x="10px" y="550px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
 </tspan>
-    <tspan x="10px" y="568px">
+    <tspan x="10px" y="568px"><tspan>      --all-targets     Fix all targets</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>Feature Selection:</tspan>
+    <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="604px"><tspan>Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      --all-features         Activate all available features</tspan>
+    <tspan x="10px" y="622px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="640px"><tspan>      --all-features         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="658px">
+    <tspan x="10px" y="658px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
+</tspan>
+    <tspan x="10px" y="676px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Current behavior
- When `--broken-code` is not applied 
  - Error found while fixing specific build unit (`current_target` is `Some`)
    - Current errors and original errors are printed
    - files are reverted to original state
  - Error found when `current_target` is `None`
    - Print all messages
- When `--broken-code` is applied
  - Fix all machine applicable messages

Fixes #29