### PR TITLE
Reuse verification passes between fixed build targets

### DIFF
--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -150,7 +150,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
             anyhow::bail!("could not compile");
         }
 
-        let (mut errors, build_unit_map) = collect_errors(messages.into_iter(), &seen);
+        let (mut errors, mut build_unit_map) = collect_errors(messages.into_iter(), &seen);
 
         if iteration >= max_iterations {
             if let Some(target) = current_target {
@@ -171,6 +171,17 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
             }
         }
 
+        let mut finalized_target = false;
+        if let Some(target) = current_target.as_ref() {
+            if build_unit_map.get(target).is_none_or(IndexMap::is_empty) {
+                let target = current_target.take().expect("current target is present");
+                build_unit_map.shift_remove(&target);
+                finish_target(target, &mut files, &mut errors, &mut seen)?;
+                iteration = 0;
+                finalized_target = true;
+            }
+        }
+
         let mut made_changes = false;
 
         for (build_unit, file_map) in build_unit_map {
@@ -183,6 +194,9 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                 .or_insert_with(IndexSet::new);
 
             if current_target.is_none() && file_map.is_empty() {
+                if finalized_target && build_unit_errors.is_empty() {
+                    continue;
+                }
                 if seen.iter().all(|b| b.package_id != build_unit.package_id) {
                     shell::status("Checking", format_package_id(&build_unit.package_id)?)?;
                 }
@@ -212,9 +226,9 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                 finish_target(pkg, &mut files, &mut last_errors, &mut seen)?;
                 current_target = None;
                 iteration = 0;
-            } else {
-                break;
+                continue;
             }
+            break;
         }
     }
 

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -154,30 +154,16 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
         if iteration >= max_iterations {
             if let Some(target) = current_target {
-                if seen.iter().all(|b| b.package_id != target.package_id) {
-                    shell::status("Checking", format_package_id(&target.package_id)?)?;
+                if let Some(file_map) = build_unit_map.get(&target) {
+                    let target_errors = errors.entry(target.clone()).or_default();
+                    target_errors.extend(
+                        file_map
+                            .values()
+                            .flatten()
+                            .filter_map(|(_, diagnostic)| diagnostic.clone()),
+                    );
                 }
-
-                for (name, file) in files {
-                    shell::fixed(name, file.fixes)?;
-                }
-                files = IndexMap::new();
-
-                let mut errors = errors.shift_remove(&target).unwrap_or_else(IndexSet::new);
-
-                if let Some(e) = build_unit_map.get(&target) {
-                    for (_, e) in e.iter().flat_map(|(_, s)| s) {
-                        let Some(e) = e else {
-                            continue;
-                        };
-                        errors.insert(e.to_owned());
-                    }
-                }
-                for e in errors {
-                    shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
-                }
-
-                seen.insert(target);
+                finish_target(target, &mut files, &mut errors, &mut seen)?;
                 current_target = None;
                 iteration = 0;
             } else {
@@ -223,21 +209,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
         if !made_changes {
             if let Some(pkg) = current_target {
-                if seen.iter().all(|b| b.package_id != pkg.package_id) {
-                    shell::status("Checking", format_package_id(&pkg.package_id)?)?;
-                }
-
-                for (name, file) in files {
-                    shell::fixed(name, file.fixes)?;
-                }
-                files = IndexMap::new();
-
-                let errors = last_errors.shift_remove(&pkg).unwrap_or_else(IndexSet::new);
-                for e in errors {
-                    shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
-                }
-
-                seen.insert(pkg);
+                finish_target(pkg, &mut files, &mut last_errors, &mut seen)?;
                 current_target = None;
                 iteration = 0;
             } else {
@@ -254,6 +226,32 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
         shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
     }
 
+    Ok(())
+}
+
+/// Marks a target complete after reporting its fixes and remaining diagnostics.
+fn finish_target(
+    target: BuildUnit,
+    files: &mut IndexMap<String, File>,
+    errors: &mut IndexMap<BuildUnit, IndexSet<String>>,
+    seen: &mut HashSet<BuildUnit>,
+) -> CargoResult<()> {
+    if seen
+        .iter()
+        .all(|build_unit| build_unit.package_id != target.package_id)
+    {
+        shell::status("Checking", format_package_id(&target.package_id)?)?;
+    }
+
+    for (name, file) in std::mem::take(files) {
+        shell::fixed(name, file.fixes)?;
+    }
+
+    for error in errors.shift_remove(&target).unwrap_or_default() {
+        shell::print_ansi_stderr(format!("{}\n\n", error.trim_end()).as_bytes())?;
+    }
+
+    seen.insert(target);
     Ok(())
 }
 

--- a/tests/testsuite/fix_n_times.rs
+++ b/tests/testsuite/fix_n_times.rs
@@ -327,7 +327,7 @@ fn fix_no_suggestions() {
 fn fix_one_suggestion() {
     // One suggested fix, with a successful verification, no output.
     expect_fix_runs_rustc_n_times(
-        &[Step::OneFix, Step::SuccessNoOutput, Step::SuccessNoOutput],
+        &[Step::OneFix, Step::SuccessNoOutput],
         |_execs| {},
         str![[r#"
 [CHECKING] foo v0.0.1
@@ -343,7 +343,7 @@ fn fix_one_suggestion() {
 fn fix_one_overlapping() {
     // Two suggested fixes, where one fails, then the next step returns no suggestions.
     expect_fix_runs_rustc_n_times(
-        &[Step::TwoFixOverlapping, Step::SuccessNoOutput, Step::SuccessNoOutput],
+        &[Step::TwoFixOverlapping, Step::SuccessNoOutput],
         |_execs| {},
         str![[r#"
 [CHECKING] foo v0.0.1
@@ -517,7 +517,7 @@ rustc fix shim error count=1
 fn broken_code_one_suggestion() {
     // --broken-code where there is an error and a suggestion.
     expect_fix_runs_rustc_n_times(
-        &[Step::OneFixError, Step::Error, Step::SuccessNoOutput],
+        &[Step::OneFixError, Step::Error],
         |execs| {
             execs.arg("--broken-code");
         },


### PR DESCRIPTION
## Summary

Previously, every fixed build target required a separate Cargo invocation to verify its changes. But that verification pass also returned diagnostics for the remaining targets, which we discarded before running Cargo again just to rediscover the same work. We also ran one unnecessary final check after the last target was already verified.

This PR reuses each verification pass as the next diagnostic snapshot. Once the current target no longer has any applicable fixes, finalize it and immediately process the other targets from that same compiler run:

```
Before: check -> fix A -> check -> finalize A -> check -> fix B -> check -> finalize B -> check
After:  check -> fix A -> check / finalize A / fix B -> check / finalize B
```

Every modification is still verified by a subsequent compiler invocation before its target is marked complete, and the next target's suggestions always come from a snapshot that includes all earlier fixes. The shared finalization helper preserves package-status output, fixed-file reporting, remaining diagnostics, retry limits, and the existing rollback behavior for failed fixes.

On a workspace with 20 independently fixable crates, Cargo invocations fall from **41 to 21**, improving runtime from **4.21 s to 1.74 s** (2.42x). A single fix improves from **412 ms to 189 ms**.
