### PR TITLE
Preserve dependency caches when fixing compiler and Clippy lints

### DIFF
--- a/src/ops/check.rs
+++ b/src/ops/check.rs
@@ -20,7 +20,23 @@ pub struct Artifact {
 pub struct Message {
     #[serde(flatten)]
     pub build_unit: BuildUnit,
-    pub message: Diagnostic,
+    pub message: MessageDiagnostic,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct MessageDiagnostic {
+    #[serde(flatten)]
+    pub level: DiagnosticLevel,
+    #[serde(flatten)]
+    pub diagnostic: Diagnostic,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[serde(tag = "level", rename_all = "lowercase")]
+pub enum DiagnosticLevel {
+    Error,
+    #[serde(other)]
+    Other,
 }
 
 #[derive(Deserialize, Hash, PartialEq, Clone, Eq, Debug)]

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -14,7 +14,7 @@ use tracing::{trace, warn};
 
 use crate::{
     core::{shell, sysroot::get_sysroot},
-    ops::check::{BuildUnit, CheckOutput, Message, MessageDiagnostic},
+    ops::check::{BuildUnit, CheckOutput, DiagnosticLevel, Message, MessageDiagnostic},
     util::{
         cli::CheckFlags, messages::gen_please_report_this_bug_text, package::format_package_id,
         vcs::VcsOpts,
@@ -67,6 +67,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
         .and_then(|i| i.parse().ok())
         .unwrap_or(4);
     let mut iteration = 0;
+    let mut lint_cap = false;
 
     let mut last_errors = IndexMap::new();
     let mut current_target: Option<BuildUnit> = None;
@@ -75,7 +76,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     loop {
         trace!("iteration={iteration}");
         trace!("current_target={current_target:?}");
-        let (messages, exit_code) = check(&args)?;
+        let (messages, exit_code) = check(&args, &mut lint_cap)?;
 
         if !args.broken_code && exit_code != Some(0) {
             let mut out = String::new();
@@ -117,7 +118,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                     out.push_str(&format!("{}\n\n", e.trim_end()));
                 }
 
-                let (messages, _) = check(&args)?;
+                let (messages, _) = check(&args, &mut lint_cap)?;
                 let mut errors = messages
                     .filter_map(|e| match e {
                         CheckOutput::Message(m) => m.message.diagnostic.rendered,
@@ -254,27 +255,54 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     Ok(())
 }
 
-fn check(args: &FixitArgs) -> CargoResult<(impl Iterator<Item = CheckOutput>, Option<i32>)> {
+fn check(
+    args: &FixitArgs,
+    lint_cap: &mut bool,
+) -> CargoResult<(impl Iterator<Item = CheckOutput>, Option<i32>)> {
     let cmd = if args.clippy { "clippy" } else { "check" };
     let mut command = std::process::Command::new(env!("CARGO"));
     command
         .args([cmd, "--message-format", "json-diagnostic-rendered-ansi"])
         .args(args.check_flags.to_flags());
-    cap_lints(&mut command);
 
-    let output = command
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .output()?;
+    if *lint_cap {
+        cap_lints(&mut command);
+    }
 
-    let buf = BufReader::new(Cursor::new(output.stdout));
+    command.stderr(Stdio::piped()).stdout(Stdio::piped());
+    let output = command.output()?;
+    let mut exit_code = output.status.code();
+    let mut messages = parse_messages(output.stdout);
+    let mut buffered = Vec::new();
 
-    Ok((
-        buf.lines()
-            .map_while(|l| l.ok())
-            .filter_map(|l| serde_json::from_str(&l).ok()),
-        output.status.code(),
-    ))
+    if exit_code != Some(0) && !*lint_cap {
+        while let Some(message) = messages.next() {
+            let denied_lint = matches!(&message, CheckOutput::Message(message)
+                if message.message.level == DiagnosticLevel::Error
+                    && message.message.diagnostic.code.is_some());
+            buffered.push(message);
+
+            if denied_lint {
+                *lint_cap = true;
+                cap_lints(&mut command);
+                let output = command.output()?;
+                exit_code = output.status.code();
+                buffered.clear();
+                messages = parse_messages(output.stdout);
+                break;
+            }
+        }
+    }
+
+    Ok((buffered.into_iter().chain(messages), exit_code))
+}
+
+/// Parses Cargo's compiler diagnostics and artifacts without buffering them.
+fn parse_messages(stdout: Vec<u8>) -> impl Iterator<Item = CheckOutput> {
+    BufReader::new(Cursor::new(stdout))
+        .lines()
+        .map_while(|line| line.ok())
+        .filter_map(|line| serde_json::from_str(&line).ok())
 }
 
 /// Applies the original lint cap while preserving existing compiler flags.

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -14,7 +14,7 @@ use tracing::{trace, warn};
 
 use crate::{
     core::{shell, sysroot::get_sysroot},
-    ops::check::{BuildUnit, CheckOutput, Message},
+    ops::check::{BuildUnit, CheckOutput, Message, MessageDiagnostic},
     util::{
         cli::CheckFlags, messages::gen_please_report_this_bug_text, package::format_package_id,
         vcs::VcsOpts,
@@ -105,7 +105,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
                 let mut errors = messages
                     .filter_map(|e| match e {
-                        CheckOutput::Message(m) => m.message.rendered,
+                        CheckOutput::Message(m) => m.message.diagnostic.rendered,
                         _ => None,
                     })
                     .peekable();
@@ -120,7 +120,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                 let (messages, _) = check(&args)?;
                 let mut errors = messages
                     .filter_map(|e| match e {
-                        CheckOutput::Message(m) => m.message.rendered,
+                        CheckOutput::Message(m) => m.message.diagnostic.rendered,
                         _ => None,
                     })
                     .peekable();
@@ -136,7 +136,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                 shell::warn(out)?;
             } else {
                 for e in messages.filter_map(|e| match e {
-                    CheckOutput::Message(m) => m.message.rendered,
+                    CheckOutput::Message(m) => m.message.diagnostic.rendered,
                     _ => None,
                 }) {
                     shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
@@ -305,7 +305,7 @@ fn collect_errors(
     for message in messages {
         let Message {
             build_unit,
-            message: diagnostic,
+            message: MessageDiagnostic { diagnostic, .. },
         } = match message {
             CheckOutput::Message(m) => m,
             CheckOutput::Artifact(a) => {

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -256,29 +256,36 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
 fn check(args: &FixitArgs) -> CargoResult<(impl Iterator<Item = CheckOutput>, Option<i32>)> {
     let cmd = if args.clippy { "clippy" } else { "check" };
-    let command = std::process::Command::new(env!("CARGO"))
+    let mut command = std::process::Command::new(env!("CARGO"));
+    command
         .args([cmd, "--message-format", "json-diagnostic-rendered-ansi"])
-        .args(args.check_flags.to_flags())
-        // This allows `cargo fix` to work even if the crate has #[deny(warnings)].
-        .env(
-            "RUSTFLAGS",
-            format!(
-                "--cap-lints=warn {}",
-                env::var("RUSTFLAGS").unwrap_or("".to_owned())
-            ),
-        )
+        .args(args.check_flags.to_flags());
+    cap_lints(&mut command);
+
+    let output = command
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
         .output()?;
 
-    let buf = BufReader::new(Cursor::new(command.stdout));
+    let buf = BufReader::new(Cursor::new(output.stdout));
 
     Ok((
         buf.lines()
             .map_while(|l| l.ok())
             .filter_map(|l| serde_json::from_str(&l).ok()),
-        command.status.code(),
+        output.status.code(),
     ))
+}
+
+/// Applies the original lint cap while preserving existing compiler flags.
+fn cap_lints(command: &mut std::process::Command) {
+    command.env(
+        "RUSTFLAGS",
+        format!(
+            "--cap-lints=warn {}",
+            env::var("RUSTFLAGS").unwrap_or("".to_owned())
+        ),
+    );
 }
 
 #[tracing::instrument(skip_all)]

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -263,6 +263,37 @@ fn do_not_fix_non_relevant_deps() {
 }
 
 #[cargo_test]
+fn clippy_fixes_denied_warnings_in_external_path_dependencies() {
+    let p = project()
+        .no_manifest()
+        .file(
+            "foo/Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                bar = { path = '../bar' }
+
+                [workspace]
+            "#,
+        )
+        .file("foo/src/lib.rs", "pub fn foo() { bar::foo(); }")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file(
+            "bar/src/lib.rs",
+            "#![deny(warnings)]\npub fn foo() { let mut value = 1; let _ = value; }\n",
+        )
+        .build();
+
+    p.cargo_("fix --clippy --allow-no-vcs").cwd("foo").run();
+
+    assert!(!p.read_file("bar/src/lib.rs").contains("let mut value"));
+}
+
+#[cargo_test]
 fn prepare_for_2018() {
     let p = project()
         .file(

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -1,5 +1,5 @@
 use cargo_test_support::cargo_test;
-use cargo_test_support::{basic_manifest, compare::assert_ui, project};
+use cargo_test_support::{basic_manifest, compare::assert_ui, project, Project};
 use snapbox::str;
 
 use crate::fix::FixitProject;
@@ -37,6 +37,136 @@ fn basic() {
             
 "#]],
     );
+}
+
+#[cargo_test]
+fn preserves_workspace_fingerprints_without_denied_warnings() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                cached-dependency = { path = "cached-dependency" }
+            "#,
+        )
+        .file("src/lib.rs", "pub fn foo() { cached_dependency::foo(); }")
+        .file(
+            "cached-dependency/Cargo.toml",
+            &basic_manifest("cached-dependency", "0.1.0"),
+        )
+        .file("cached-dependency/src/lib.rs", "pub fn foo() {}")
+        .build();
+
+    p.cargo_("check").run();
+
+    let fingerprints_before = package_fingerprints(&p, &["foo-", "cached-dependency-"]);
+    assert_eq!(fingerprints_before.len(), 2);
+
+    p.cargo_("fixit --allow-no-vcs").run();
+
+    assert_eq!(
+        package_fingerprints(&p, &["foo-", "cached-dependency-"]),
+        fingerprints_before
+    );
+}
+
+#[cargo_test]
+fn clippy_preserves_workspace_fingerprints_without_denied_warnings() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = ['app', 'cached-dependency']\nresolver = '2'\n",
+        )
+        .file(
+            "app/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\ncached-dependency = {{ path = '../cached-dependency' }}\n",
+                basic_manifest("app", "0.1.0")
+            ),
+        )
+        .file(
+            "app/src/lib.rs",
+            "pub fn app() { cached_dependency::foo(); }\n",
+        )
+        .file(
+            "cached-dependency/Cargo.toml",
+            &basic_manifest("cached-dependency", "0.1.0"),
+        )
+        .file("cached-dependency/src/lib.rs", "pub fn foo() {}\n")
+        .build();
+
+    p.cargo_("clippy --workspace").run();
+
+    let fingerprints_before = package_fingerprints(&p, &["app-", "cached-dependency-"]);
+    assert_eq!(fingerprints_before.len(), 2);
+
+    p.cargo_("fixit --clippy --workspace --allow-no-vcs").run();
+
+    assert_eq!(
+        package_fingerprints(&p, &["app-", "cached-dependency-"]),
+        fingerprints_before
+    );
+}
+
+#[cargo_test]
+fn clippy_fixes_denied_warnings() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            "#![deny(warnings)]\npub fn a() { let mut value = 1; let _ = value; }\n",
+        )
+        .build();
+
+    p.cargo_("fixit --clippy --allow-no-vcs")
+        .with_status(0)
+        .run();
+
+    assert!(!p.read_file("src/lib.rs").contains("let mut value"));
+}
+
+#[cargo_test]
+fn fixes_denied_lints_with_compiler_error_codes() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            "#![allow(unused_variables, non_snake_case)]\nenum Choice { Value }\npub fn check() { match Choice::Value { Value => {} } }\n",
+        )
+        .build();
+
+    p.cargo_("fixit --allow-no-vcs").run();
+
+    assert!(p.read_file("src/lib.rs").contains("Choice::Value =>"));
+}
+
+fn package_fingerprints(project: &Project, packages: &[&str]) -> Vec<(String, Vec<u8>)> {
+    let mut fingerprints = std::fs::read_dir(project.build_dir().join("debug/.fingerprint"))
+        .unwrap()
+        .map(Result::unwrap)
+        .filter(|entry| {
+            let name = entry.file_name();
+            packages
+                .iter()
+                .any(|package| name.to_string_lossy().starts_with(package))
+        })
+        .map(|entry| {
+            let dep_info = std::fs::read_dir(entry.path())
+                .unwrap()
+                .map(Result::unwrap)
+                .find(|file| file.file_name().to_string_lossy().starts_with("dep-lib-"))
+                .unwrap();
+            (
+                entry.file_name().to_string_lossy().into_owned(),
+                std::fs::read(dep_info.path()).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    fingerprints.sort_unstable();
+    fingerprints
 }
 
 #[cargo_test]


### PR DESCRIPTION
## Summary

Previously, every fix pass injected `--cap-lints=warn` into `RUSTFLAGS` so crates using `#![deny(warnings)]` could still be fixed. Changing those global compiler flags also invalidated Cargo fingerprints for every dependency, forcing otherwise warm workspaces to rebuild.

We now run both compiler and Clippy checks without changing any flags. If a denied lint blocks compilation, we retry with the original global lint cap and retain it for subsequent fix and verification passes. This preserves fixes for denied warnings, including warnings in external path dependencies, without invalidating dependency caches on the common path.

On a warmed workspace with two local crates and nine registry dependencies, ordinary compiler fixes improve from **1.33 s to 110 ms** (12.1x), while Clippy fixes improve from **1.37 s to 90 ms** (15.2x).