### PR TITLE
Batch fixes for independent packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "camino"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cargo-fixit"
 version = "0.1.8"
 dependencies = [
@@ -180,6 +189,7 @@ dependencies = [
  "cargo-test-support",
  "cargo-util",
  "cargo-util-schemas",
+ "cargo_metadata",
  "clap",
  "clap-cargo",
  "colorchoice-clap",
@@ -187,12 +197,23 @@ dependencies = [
  "indexmap",
  "log",
  "rustfix",
+ "same-file",
  "serde",
  "serde_json",
  "snapbox",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -267,6 +288,20 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "unicode-xid",
  "url",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,12 +125,14 @@ default = []
 
 [dependencies]
 anyhow = "1.0.104"
+cargo_metadata = "0.23.1"
 clap = { version = "4.6.4", features = ["derive"] }
 clap-cargo = "0.18.3"
 tracing = { version = "0.1.44", default-features = false, features = ["std", "attributes"] }
 tracing-chrome = "0.7.2"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 rustfix = "0.9.4"
+same-file = "1.0.6"
 serde = { version = "1.0.229", features = ["derive"]}
 serde_json = "1.0.151"
 cargo-util = "0.2.24"

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -84,18 +84,17 @@ fn fix(
     let mut lint_cap = false;
 
     let mut last_errors = IndexMap::new();
-    let mut current_target: Option<BuildUnit> = None;
     let mut seen = HashSet::new();
 
     loop {
         trace!("iteration={iteration}");
-        trace!("current_target={current_target:?}");
+        trace!("active_targets={active_targets:?}");
         let (messages, exit_code) = check(args, &mut lint_cap)?;
 
         if !args.broken_code && exit_code != Some(0) {
             let mut out = String::new();
 
-            if current_target.is_some() {
+            if !active_targets.is_empty() {
                 out.push_str(
                     "failed to automatically apply fixes suggested by rustc\n\n\
                     after fixes were automatically applied the \
@@ -168,7 +167,11 @@ fn fix(
         let (mut errors, mut build_unit_map) = collect_errors(messages.into_iter(), &seen);
 
         if iteration >= max_iterations {
-            if let Some(target) = current_target {
+            if active_targets.is_empty() {
+                break;
+            }
+            let targets: Vec<_> = active_targets.keys().cloned().collect();
+            for target in targets {
                 if let Some(file_map) = build_unit_map.get(&target) {
                     let target_errors = errors.entry(target.clone()).or_default();
                     target_errors.extend(
@@ -179,22 +182,24 @@ fn fix(
                     );
                 }
                 finish_target(target, active_targets, &mut errors, &mut seen)?;
-                current_target = None;
-                iteration = 0;
-            } else {
-                break;
             }
+            iteration = 0;
         }
 
-        let mut finalized_target = false;
-        if let Some(target) = current_target.as_ref() {
-            if build_unit_map.get(target).is_none_or(IndexMap::is_empty) {
-                let target = current_target.take().expect("current target is present");
+        let mut finalized_targets = false;
+        if !active_targets.is_empty()
+            && active_targets
+                .keys()
+                .all(|target| build_unit_map.get(target).is_none_or(IndexMap::is_empty))
+        {
+            let targets: Vec<_> = active_targets.keys().cloned().collect();
+            for target in targets {
                 build_unit_map.shift_remove(&target);
                 finish_target(target, active_targets, &mut errors, &mut seen)?;
-                iteration = 0;
-                finalized_target = true;
             }
+            debug_assert!(active_targets.is_empty());
+            iteration = 0;
+            finalized_targets = true;
         }
 
         let mut made_changes = false;
@@ -208,8 +213,8 @@ fn fix(
                 .entry(build_unit.clone())
                 .or_insert_with(IndexSet::new);
 
-            if current_target.is_none() && file_map.is_empty() {
-                if finalized_target && build_unit_errors.is_empty() {
+            if active_targets.is_empty() && file_map.is_empty() {
+                if finalized_targets && build_unit_errors.is_empty() {
                     continue;
                 }
                 if seen.iter().all(|b| b.package_id != build_unit.package_id) {
@@ -222,32 +227,32 @@ fn fix(
 
                 seen.insert(build_unit);
             } else if !file_map.is_empty()
-                && current_target.get_or_insert(build_unit.clone()) == &build_unit
+                && (active_targets.is_empty() || active_targets.contains_key(&build_unit))
             {
                 let target_files = active_targets.entry(build_unit.clone()).or_default();
                 if fix_errors(target_files, file_map, build_unit_errors)? {
                     made_changes = true;
                     break;
-                } else if target_files.is_empty() {
-                    active_targets.shift_remove(&build_unit);
                 }
             }
         }
 
         trace!("made_changes={made_changes:?}");
-        trace!("current_target={current_target:?}");
+        trace!("active_targets={active_targets:?}");
 
         last_errors = errors;
         iteration += 1;
 
         if !made_changes {
-            if let Some(pkg) = current_target {
-                finish_target(pkg, active_targets, &mut last_errors, &mut seen)?;
-                current_target = None;
-                iteration = 0;
-                continue;
+            if active_targets.is_empty() {
+                break;
             }
-            break;
+            let targets: Vec<_> = active_targets.keys().cloned().collect();
+            for target in targets {
+                finish_target(target, active_targets, &mut last_errors, &mut seen)?;
+            }
+            iteration = 0;
+            continue;
         }
     }
 

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -1,11 +1,14 @@
-use std::{
-    collections::HashSet,
-    env,
-    io::{BufRead, BufReader, Cursor},
-    path::Path,
-    process::Stdio,
-};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::env;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Cursor;
+use std::path::Path;
+use std::process::Command;
+use std::process::Stdio;
 
+use cargo_metadata::MetadataCommand;
 use cargo_util::paths;
 use clap::Parser;
 use indexmap::{IndexMap, IndexSet};
@@ -84,6 +87,8 @@ fn fix(
     let mut lint_cap = false;
 
     let mut last_errors = IndexMap::new();
+    let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
+    let mut package_graph = PackageGraph::load(&args.check_flags);
     let mut seen = HashSet::new();
 
     loop {
@@ -183,6 +188,7 @@ fn fix(
                 }
                 finish_target(target, active_targets, &mut errors, &mut seen)?;
             }
+            claimed_files.clear();
             iteration = 0;
         }
 
@@ -198,11 +204,15 @@ fn fix(
                 finish_target(target, active_targets, &mut errors, &mut seen)?;
             }
             debug_assert!(active_targets.is_empty());
+            claimed_files.clear();
             iteration = 0;
             finalized_targets = true;
         }
 
         let mut made_changes = false;
+        // Admit build units from one compiler snapshot only when their packages are independent.
+        // Once a batch is active, recheck and finish it before considering additional units.
+        let continuing_batch = !active_targets.is_empty();
 
         for (build_unit, file_map) in build_unit_map {
             if seen.contains(&build_unit) {
@@ -226,13 +236,65 @@ fn fix(
                 errors.shift_remove(&build_unit);
 
                 seen.insert(build_unit);
-            } else if !file_map.is_empty()
-                && (active_targets.is_empty() || active_targets.contains_key(&build_unit))
-            {
+            } else if !file_map.is_empty() {
+                if continuing_batch && !active_targets.contains_key(&build_unit) {
+                    continue;
+                }
+
+                let was_active = active_targets.contains_key(&build_unit);
+                if !was_active && !active_targets.is_empty() {
+                    let Some(graph) = package_graph.as_mut() else {
+                        continue;
+                    };
+
+                    let mut independent = true;
+                    for active in active_targets.keys() {
+                        if !graph
+                            .packages_are_independent(&active.package_id, &build_unit.package_id)
+                        {
+                            independent = false;
+                            break;
+                        }
+                    }
+                    if !independent {
+                        continue;
+                    }
+                }
+
+                let handles = file_map
+                    .keys()
+                    .map(same_file::Handle::from_path)
+                    .collect::<Result<Vec<_>, _>>()
+                    .ok();
+                let serialize_target = handles.is_none();
+                if serialize_target && !was_active && !active_targets.is_empty() {
+                    continue;
+                }
+                if handles.as_ref().is_some_and(|handles| {
+                    handles.iter().any(|handle| {
+                        claimed_files
+                            .get(handle)
+                            .is_some_and(|owner| owner != &build_unit)
+                    })
+                }) {
+                    continue;
+                }
+
                 let target_files = active_targets.entry(build_unit.clone()).or_default();
-                if fix_errors(target_files, file_map, build_unit_errors)? {
+                let changed = fix_errors(target_files, file_map, build_unit_errors)?;
+                if !changed && !was_active {
+                    active_targets.shift_remove(&build_unit);
+                }
+                if changed {
+                    if let Some(handles) = handles {
+                        for handle in handles {
+                            claimed_files.entry(handle).or_insert(build_unit.clone());
+                        }
+                    }
                     made_changes = true;
-                    break;
+                    if serialize_target {
+                        break;
+                    }
                 }
             }
         }
@@ -251,6 +313,7 @@ fn fix(
             for target in targets {
                 finish_target(target, active_targets, &mut last_errors, &mut seen)?;
             }
+            claimed_files.clear();
             iteration = 0;
             continue;
         }
@@ -268,6 +331,87 @@ fn fix(
 
     active_targets.clear();
     Ok(())
+}
+
+/// Resolved package dependencies used to batch only transitively unrelated packages.
+#[derive(Debug)]
+struct PackageGraph {
+    dependencies: HashMap<String, Vec<String>>,
+    reachable: HashMap<String, HashSet<String>>,
+}
+
+impl PackageGraph {
+    /// Loads the package graph, returning `None` when batching must remain serial.
+    fn load(flags: &CheckFlags) -> Option<Self> {
+        let mut command = MetadataCommand::new();
+        command.other_options(flags.to_metadata_flags());
+
+        let metadata = match command.exec() {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                warn!("failed to run `cargo metadata`: {error}");
+                return None;
+            }
+        };
+        let Some(resolve) = metadata.resolve else {
+            warn!("`cargo metadata` did not return a dependency graph");
+            return None;
+        };
+        let dependencies = resolve
+            .nodes
+            .into_iter()
+            .map(|node| {
+                (
+                    node.id.repr,
+                    node.dependencies
+                        .into_iter()
+                        .map(|dependency| dependency.repr)
+                        .collect(),
+                )
+            })
+            .collect();
+
+        Some(Self {
+            dependencies,
+            reachable: HashMap::new(),
+        })
+    }
+
+    /// Returns whether both packages are known and transitively unrelated.
+    fn packages_are_independent(&mut self, left: &str, right: &str) -> bool {
+        left != right && !self.depends_on(left, right) && !self.depends_on(right, left)
+    }
+
+    /// Returns whether `package` transitively depends on `target`.
+    fn depends_on(&mut self, package: &str, target: &str) -> bool {
+        if !self.reachable.contains_key(package) {
+            let Some(reachable) = self.collect_reachable(package) else {
+                return true;
+            };
+            self.reachable.insert(package.to_owned(), reachable);
+        }
+
+        self.reachable
+            .get(package)
+            .is_none_or(|reachable| reachable.contains(target))
+    }
+
+    /// Collects the packages transitively reachable from `root`.
+    fn collect_reachable(&self, root: &str) -> Option<HashSet<String>> {
+        let mut reachable = HashSet::new();
+        let mut pending = vec![root];
+
+        while let Some(package) = pending.pop() {
+            if !reachable.insert(package.to_owned()) {
+                continue;
+            }
+            let dependencies = self.dependencies.get(package)?;
+            pending.extend(dependencies.iter().map(String::as_str));
+        }
+
+        reachable.remove(root);
+        Some(reachable)
+    }
 }
 
 /// Marks a target complete after reporting its fixes and remaining diagnostics.
@@ -302,7 +446,7 @@ fn finish_target(
 
 fn check(args: &FixitArgs, lint_cap: &mut bool) -> CargoResult<(Vec<CheckOutput>, Option<i32>)> {
     let cmd = if args.clippy { "clippy" } else { "check" };
-    let mut command = std::process::Command::new(env!("CARGO"));
+    let mut command = Command::new(env!("CARGO"));
     command
         .args([cmd, "--message-format", "json-diagnostic-rendered-ansi"])
         .args(args.check_flags.to_flags())
@@ -324,7 +468,7 @@ fn check(args: &FixitArgs, lint_cap: &mut bool) -> CargoResult<(Vec<CheckOutput>
 }
 
 /// Applies the original lint cap while preserving existing compiler flags.
-fn cap_lints(command: &mut std::process::Command) {
+fn cap_lints(command: &mut Command) {
     if let Ok(flags) = env::var("CARGO_ENCODED_RUSTFLAGS") {
         let separator = if flags.is_empty() { "" } else { "\u{1f}" };
         command.env(

--- a/src/util/cli.rs
+++ b/src/util/cli.rs
@@ -246,4 +246,47 @@ impl CheckFlags {
         }
         out
     }
+
+    /// Returns flags that can affect dependency resolution.
+    ///
+    /// Package and target filters are omitted so the resulting graph stays conservative.
+    pub(crate) fn to_metadata_flags(&self) -> Vec<String> {
+        let mut out = Vec::new();
+
+        for feature in &self.features {
+            out.push("--features".to_owned());
+            out.push(feature.clone());
+        }
+        if self.all_features {
+            out.push("--all-features".to_owned());
+        }
+        if self.no_default_features {
+            out.push("--no-default-features".to_owned());
+        }
+
+        for flag in &self.unstable_flags {
+            out.push("-Z".to_owned());
+            out.push(flag.clone());
+        }
+
+        if let Some(path) = &self.manifest_path {
+            out.push("--manifest-path".to_owned());
+            out.push(path.clone());
+        }
+        if let Some(path) = &self.lockfile_path {
+            out.push("--lockfile-path".to_owned());
+            out.push(path.clone());
+        }
+        if self.locked {
+            out.push("--locked".to_owned());
+        }
+        if self.offline {
+            out.push("--offline".to_owned());
+        }
+        if self.frozen {
+            out.push("--frozen".to_owned());
+        }
+
+        out
+    }
 }

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -28,7 +28,9 @@ pub(crate) fn echo_wrapper() -> PathBuf {
         .file(
             "src/main.rs",
             r#"
+            use std::fs::OpenOptions;
             use std::fs::read_to_string;
+            use std::io::Write as _;
             use std::path::PathBuf;
             fn main() {
                 // Handle args from `@path` argfile for rustc
@@ -39,6 +41,20 @@ pub(crate) fn echo_wrapper() -> PathBuf {
                         vec![p]
                     })
                 .collect::<Vec<_>>();
+                if let Some(path) = std::env::var_os("__CARGO_FIXIT_RUSTC_LOG") {
+                    let path = PathBuf::from(path);
+                    if let Some(crate_name) = args
+                        .windows(2)
+                        .find_map(|args| (args[0] == "--crate-name").then_some(&args[1]))
+                    {
+                        let mut log = OpenOptions::new()
+                            .append(true)
+                            .create(true)
+                            .open(path.join(crate_name))
+                            .unwrap();
+                        writeln!(log, "{crate_name}").unwrap();
+                    }
+                }
                 eprintln!("WRAPPER CALLED: {}", args[1..].join(" "));
                 let status = std::process::Command::new(&args[1])
                     .args(&args[2..]).status().unwrap();
@@ -51,6 +67,18 @@ pub(crate) fn echo_wrapper() -> PathBuf {
     let path = p.bin("rustc-echo-wrapper");
     *lock = Some(path.clone());
     path
+}
+
+pub(crate) fn rustc_invocations<const N: usize>(
+    path: &Path,
+    crate_names: [&str; N],
+) -> [usize; N] {
+    crate_names.map(|crate_name| {
+        std::fs::read_to_string(path.join(crate_name))
+            .unwrap()
+            .lines()
+            .count()
+    })
 }
 
 pub(crate) trait FixitProject {

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -1,6 +1,7 @@
 use cargo_test_support::cargo_test;
 use cargo_test_support::{basic_manifest, compare::assert_ui, project, Project};
 use snapbox::str;
+use snapbox::IntoData as _;
 
 use crate::fix::FixitProject;
 
@@ -354,7 +355,70 @@ fn retains_completed_target_when_later_write_fails() {
 }
 
 #[cargo_test]
-fn dependency_order() {
+fn independent_workspace_packages() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"a\", \"b\"]\nresolver = \"2\"\n",
+        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
+        .file("a/src/lib.rs", "pub fn a() { let mut value = 1; let _ = value; }\n")
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
+        .file("b/src/lib.rs", "pub fn b() { let mut value = 1; let _ = value; }\n")
+        .build();
+
+    p.cargo_("fixit --workspace --allow-no-vcs")
+        .with_status(0)
+        .with_stderr_data(
+            str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[FIXED] b/src/lib.rs (1 fix)
+
+"#]]
+            .unordered(),
+        )
+        .run();
+
+    for name in ["a", "b"] {
+        assert_eq!(
+            p.read_file(format!("{name}/src/lib.rs")),
+            format!("pub fn {name}() {{ let value = 1; let _ = value; }}\n")
+        );
+    }
+}
+
+#[cargo_test]
+fn hardlinked_workspace_packages() {
+    let original = "pub fn sample() -> usize { let mut value = 1; value }\n";
+    let fixed = "pub fn sample() -> usize { let value = 1; value }\n";
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"a\", \"b\"]\nresolver = \"2\"\n",
+        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
+        .file("a/src/lib.rs", original)
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
+        .file("b/src/lib.rs", "")
+        .build();
+
+    let source = p.root().join("a/src/lib.rs");
+    let hardlink = p.root().join("b/src/lib.rs");
+    std::fs::remove_file(&hardlink).unwrap();
+    std::fs::hard_link(&source, &hardlink).unwrap();
+
+    p.cargo_("fixit --workspace --allow-no-vcs --broken-code")
+        .run();
+
+    assert_eq!(p.read_file("a/src/lib.rs"), fixed);
+    assert_eq!(p.read_file("b/src/lib.rs"), fixed);
+    p.cargo_("check --workspace").run();
+}
+
+#[cargo_test]
+fn dependency_chain_is_fixed_sequentially() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -395,9 +459,13 @@ fn dependency_order() {
         .file("d/Cargo.toml", &basic_manifest("d", "0.1.0"))
         .file("d/src/lib.rs", "use std as foo;")
         .build();
+    let rustc_log = p.root().join("rustc.log");
+    std::fs::create_dir_all(&rustc_log).unwrap();
 
     p.cargo_("build").with_status(0).run();
     p.cargo_("fixit --allow-no-vcs")
+        .env("RUSTC_WORKSPACE_WRAPPER", crate::fix::echo_wrapper())
+        .env("__CARGO_FIXIT_RUSTC_LOG", &rustc_log)
         .with_status(0)
         .with_stderr_data(str![[r#"
 ...
@@ -409,18 +477,91 @@ fn dependency_order() {
 
 "#]])
         .run();
+
+    let crate_invocations = crate::fix::rustc_invocations(&rustc_log, ["a", "b", "c", "d"]);
+    assert_eq!(crate_invocations, [5, 3, 2, 2]);
+}
+
+#[cargo_test]
+fn dev_dependency_cycle_is_fixed_sequentially() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"a\", \"b\", \"c\"]\nresolver = \"2\"\n",
+        )
+        .file(
+            "a/Cargo.toml",
+            &format!(
+                "{}\n[dev-dependencies]\nb = {{ path = '../b' }}\n",
+                basic_manifest("a", "0.1.0")
+            ),
+        )
+        .file(
+            "a/src/lib.rs",
+            "pub fn a() -> usize { let mut value = 1; value }\n",
+        )
+        .file(
+            "a/tests/cycle.rs",
+            "#[test]\nfn cycle() { let mut value = b::b(); assert_eq!(value, 1); }\n",
+        )
+        .file(
+            "b/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\nc = {{ path = '../c' }}\n",
+                basic_manifest("b", "0.1.0")
+            ),
+        )
+        .file(
+            "b/src/lib.rs",
+            "pub fn b() -> usize { let mut value = c::c(); value }\n",
+        )
+        .file(
+            "c/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\na = {{ path = '../a' }}\n",
+                basic_manifest("c", "0.1.0")
+            ),
+        )
+        .file(
+            "c/src/lib.rs",
+            "pub fn c() -> usize { let mut value = a::a(); value }\n",
+        )
+        .build();
+
+    p.cargo_("fixit --workspace --all-targets --allow-no-vcs")
+        .run();
+
+    for path in [
+        "a/src/lib.rs",
+        "a/tests/cycle.rs",
+        "b/src/lib.rs",
+        "c/src/lib.rs",
+    ] {
+        assert!(!p.read_file(path).contains("let mut"));
+    }
+    p.cargo_("check --workspace --all-targets").run();
 }
 
 #[cargo_test]
 fn build_unit_order() {
     let p = project()
-        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file(
+            "Cargo.toml",
+            &format!(
+                "{}\n[[bin]]\nname = \"app\"\npath = \"src/main.rs\"\n",
+                basic_manifest("foo", "0.1.0")
+            ),
+        )
         .file("build.rs", "fn main(){ let mut a = 1; let _ = a; }")
         .file("src/lib.rs", "fn _a(){ let mut a = 1; let _ = a; }")
         .file("src/main.rs", "fn main(){ let mut a = 1; let _ = a; }")
         .build();
+    let rustc_log = p.root().join("rustc.log");
+    std::fs::create_dir_all(&rustc_log).unwrap();
 
     p.cargo_("fixit --allow-no-vcs")
+        .env("RUSTC_WORKSPACE_WRAPPER", crate::fix::echo_wrapper())
+        .env("__CARGO_FIXIT_RUSTC_LOG", &rustc_log)
         .with_status(0)
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.1.0
@@ -430,6 +571,113 @@ fn build_unit_order() {
 
 "#]])
         .run();
+
+    let crate_invocations =
+        crate::fix::rustc_invocations(&rustc_log, ["app", "foo", "build_script_build"]);
+    // The library is rebuilt with the binary, so both run in all four
+    // compiler passes.
+    assert_eq!(crate_invocations, [4, 4, 2]);
+}
+
+#[cargo_test]
+fn build_script_fixes_refresh_generated_source_before_downstream_fixes() {
+    let build_script = r#"
+        use std::env;
+        use std::fs;
+
+        fn main() {
+            let mut marker = 1usize;
+            let _ = marker;
+
+            let generated = if include_str!("build.rs").contains(concat!("let mut ", "marker")) {
+                "pub fn generated() {}"
+            } else {
+                "pub fn generated() { let mut value = 0; let _ = replace(&mut value, 1); }"
+            };
+            fs::write(env::var("OUT_DIR").unwrap() + "/generated.rs", generated).unwrap();
+            println!("cargo:rerun-if-changed=build.rs");
+        }
+    "#;
+
+    for (name, args) in [
+        ("normal", "fixit --allow-no-vcs"),
+        ("broken", "fixit --allow-no-vcs --broken-code"),
+    ] {
+        let p = project()
+            .at(format!("build-script-{name}"))
+            .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+            .file("build.rs", build_script)
+            .file(
+                "src/lib.rs",
+                "use std::mem::replace;\n\ninclude!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\n",
+            )
+            .build();
+
+        p.cargo_(args).run();
+
+        assert!(!p.read_file("build.rs").contains("let mut marker"));
+        assert!(p.read_file("src/lib.rs").contains("use std::mem::replace;"));
+        p.cargo_("check").run();
+    }
+}
+
+#[cargo_test]
+fn proc_macro_fixes_refresh_expansions_before_downstream_fixes() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"codegen\", \"consumer\"]\nresolver = \"2\"\n",
+        )
+        .file(
+            "codegen/Cargo.toml",
+            &format!(
+                "{}\n[lib]\nproc-macro = true\n",
+                basic_manifest("codegen", "0.1.0")
+            ),
+        )
+        .file(
+            "codegen/src/lib.rs",
+            r#"
+                extern crate proc_macro;
+
+                use proc_macro::TokenStream;
+
+                #[proc_macro]
+                pub fn generate(_: TokenStream) -> TokenStream {
+                    let mut marker = 0;
+                    let _ = marker;
+
+                    if include_str!("lib.rs").contains(concat!("let mut ", "marker")) {
+                        TokenStream::new()
+                    } else {
+                        "pub fn generated() { let mut value = 0; let _ = replace(&mut value, 1); }"
+                            .parse()
+                            .unwrap()
+                    }
+                }
+            "#,
+        )
+        .file(
+            "consumer/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\ncodegen = {{ path = '../codegen' }}\n",
+                basic_manifest("consumer", "0.1.0")
+            ),
+        )
+        .file(
+            "consumer/src/lib.rs",
+            "extern crate codegen;\n\nuse std::mem::replace;\n\ncodegen::generate!();\n",
+        )
+        .build();
+
+    p.cargo_("fixit --workspace --allow-no-vcs").run();
+
+    assert!(!p.read_file("codegen/src/lib.rs").contains("let mut marker"));
+    assert!(
+        p.read_file("consumer/src/lib.rs")
+            .contains("use std::mem::replace;")
+    );
+    p.cargo_("check --workspace").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -314,11 +314,11 @@ fn restores_prior_writes_when_later_write_fails() {
 
 #[cfg(unix)]
 #[cargo_test]
-fn retains_completed_target_when_later_write_fails() {
+fn restores_all_files_when_batched_write_fails() {
     use std::os::unix::fs::PermissionsExt;
 
     let original_a = "pub fn a() -> i32 { let mut value = 1; value }\n";
-    let original_b = "pub fn b() -> i32 { let mut value = a::a(); value }\n";
+    let original_b = "pub fn b() -> i32 { let mut value = 1; value }\n";
     let p = project()
         .file(
             "Cargo.toml",
@@ -326,10 +326,7 @@ fn retains_completed_target_when_later_write_fails() {
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", original_a)
-        .file(
-            "b/Cargo.toml",
-            "[package]\nname = \"b\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\na = { path = \"../a\" }\n",
-        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file("b/src/lib.rs", original_b)
         .build();
 
@@ -339,18 +336,13 @@ fn retains_completed_target_when_later_write_fails() {
     p.cargo_("fixit --workspace --allow-no-vcs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[CHECKING] a v0.1.0
-[FIXED] a/src/lib.rs (1 fix)
 [ERROR] failed to write `b/src/lib.rs`: [..]
 
 "#]])
         .run();
 
     std::fs::set_permissions(&unwritable, std::fs::Permissions::from_mode(0o644)).unwrap();
-    assert_eq!(
-        p.read_file("a/src/lib.rs"),
-        "pub fn a() -> i32 { let value = 1; value }\n"
-    );
+    assert_eq!(p.read_file("a/src/lib.rs"), original_a);
     assert_eq!(p.read_file("b/src/lib.rs"), original_b);
 }
 
@@ -414,11 +406,12 @@ fn hardlinked_workspace_packages() {
 
     assert_eq!(p.read_file("a/src/lib.rs"), fixed);
     assert_eq!(p.read_file("b/src/lib.rs"), fixed);
+    assert!(same_file::is_same_file(&source, &hardlink).unwrap());
     p.cargo_("check --workspace").run();
 }
 
 #[cargo_test]
-fn dependency_chain_is_fixed_sequentially() {
+fn dependency_graph_batches_only_independent_packages() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -479,7 +472,8 @@ fn dependency_chain_is_fixed_sequentially() {
         .run();
 
     let crate_invocations = crate::fix::rustc_invocations(&rustc_log, ["a", "b", "c", "d"]);
-    assert_eq!(crate_invocations, [5, 3, 2, 2]);
+    // `c` and `d` share a batch, while `b` and then `a` wait for their dependencies.
+    assert_eq!(crate_invocations, [4, 3, 2, 2]);
 }
 
 #[cargo_test]


### PR DESCRIPTION
## Summary

Previously, we applied fixes to one build target at a time and ran Cargo again after each target, even when a single compiler snapshot contained fixes for unrelated packages across the workspace.

This PR batches fixes from the same snapshot, then verifies the complete batch with one subsequent compiler invocation:

```
Before: check -> fix A -> check -> fix B -> check -> fix C -> check
After:  check -> fix A / fix B / fix C -> check
```

Packages are batched only when Cargo's resolved package graph shows that they are transitively unrelated. Dependency-related packages and all targets within the same package retain the existing one-at-a-time order, following [Cargo's dependency-ordering requirement](https://github.com/rust-lang/cargo/issues/13214#issuecomment-3245969114). Target kind does not otherwise affect batching, so build scripts and procedural macros may be fixed alongside targets from unrelated packages.

The graph is loaded once with `cargo_metadata`, and transitive dependencies are cached after their first traversal. If metadata is unavailable, processing falls back to one target at a time. Compatibility also requires distinct physical file identities, so shared files, symlinks, and hard links are never included in the same batch; targets whose files cannot be identified are processed separately.

On a warm workspace with 20 independently fixable packages, release-binary runtime across 10 runs improves from **1.368 s +/- 0.045 s to 411 ms +/- 60 ms** (3.33x), with ranges of 1.297-1.443 s and 331-521 ms. Cargo checks fall from **21 to two**, plus one metadata query. Selecting one package from the same workspace measured 136 ms +/- 20 ms before and 142 ms +/- 8 ms after across 20 runs.

Fixes #21