### PR TITLE
Avoid unnecessary Git scans and sysroot subprocesses

### DIFF
--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -408,12 +408,14 @@ fn collect_errors(
             }
         }
 
-        if let Some(sysroot) = get_sysroot() {
-            if file_path.starts_with(sysroot) {
-                if let Some(rendered) = diagnostic.rendered {
-                    errors.insert(rendered);
+        if file_path.is_absolute() {
+            if let Some(sysroot) = get_sysroot() {
+                if file_path.starts_with(sysroot) {
+                    if let Some(rendered) = diagnostic.rendered {
+                        errors.insert(rendered);
+                    }
+                    continue;
                 }
-                continue;
             }
         }
 

--- a/src/util/vcs.rs
+++ b/src/util/vcs.rs
@@ -52,6 +52,11 @@ impl VcsOpts {
         let mut repo_opts = git2::StatusOptions::new();
         repo_opts.include_ignored(false);
         repo_opts.include_untracked(true);
+        if self.allow_dirty {
+            repo_opts.show(git2::StatusShow::Index);
+        } else if self.allow_staged {
+            repo_opts.show(git2::StatusShow::Workdir);
+        }
         for status in repo.statuses(Some(&mut repo_opts))?.iter() {
             if let Some(path) = status.path() {
                 match status.status() {

--- a/src/util/vcs.rs
+++ b/src/util/vcs.rs
@@ -62,6 +62,21 @@ impl VcsOpts {
                 match status.status() {
                     git2::Status::CURRENT => (),
                     git2::Status::INDEX_NEW
+                        if repo
+                            .index()?
+                            .get_path(path.as_ref(), 0)
+                            .is_some_and(|entry| {
+                                git2::IndexEntryExtendedFlag::from_bits_truncate(
+                                    entry.flags_extended,
+                                )
+                                .is_intent_to_add()
+                            }) =>
+                    {
+                        if !self.allow_dirty {
+                            dirty_files.push(path.to_owned());
+                        }
+                    }
+                    git2::Status::INDEX_NEW
                     | git2::Status::INDEX_MODIFIED
                     | git2::Status::INDEX_DELETED
                     | git2::Status::INDEX_RENAMED

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -923,6 +923,10 @@ fn warns_about_dirty_working_directory() {
 
 "#]])
         .run();
+    p.cargo_("fix --allow-staged")
+        .with_status(101)
+        .with_stderr_contains("  * src/lib.rs (dirty)")
+        .run();
     p.cargo_("fix --allow-dirty")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.0.1
@@ -948,6 +952,10 @@ fn warns_about_staged_working_directory() {
 
 
 "#]])
+        .run();
+    p.cargo_("fix --allow-dirty")
+        .with_status(101)
+        .with_stderr_contains("  * src/lib.rs (staged)")
         .run();
     p.cargo_("fix --allow-staged")
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -966,6 +966,32 @@ fn warns_about_staged_working_directory() {
 }
 
 #[cargo_test]
+fn warns_about_intent_to_add_working_directory() {
+    let project = git::new("foo", |project| {
+        project.file("src/lib.rs", "pub fn foo() {}")
+    });
+    project.change_file("src/new.rs", "pub fn new() {}");
+    project
+        .process("git")
+        .args(&["add", "--intent-to-add", "src/new.rs"])
+        .run();
+
+    for args in ["fix", "fix --allow-staged"] {
+        project
+            .cargo_(args)
+            .with_status(101)
+            .with_stderr_contains("  * src/new.rs (dirty)")
+            .run();
+    }
+
+    project
+        .cargo_("fix --allow-dirty")
+        .with_status(101)
+        .with_stderr_contains("  * src/new.rs (staged)")
+        .run();
+}
+
+#[cargo_test]
 fn errors_about_untracked_files() {
     let mut git_project = project().at("foo");
     git_project = git_project.file("src/lib.rs", "pub fn foo() {}");

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -984,11 +984,7 @@ fn warns_about_intent_to_add_working_directory() {
             .run();
     }
 
-    project
-        .cargo_("fix --allow-dirty")
-        .with_status(101)
-        .with_stderr_contains("  * src/new.rs (staged)")
-        .run();
+    project.cargo_("fix --allow-dirty").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
## Summary

Previously, every invocation enumerated both staged and working-tree changes even when one category was explicitly allowed. We also spawned `rustc --print=sysroot` for the first applicable diagnostic, even though ordinary project diagnostics use relative paths and cannot point inside the sysroot.

This PR avoids that unnecessary work while preserving both safeguards.

For Git status, `--allow-dirty` now checks only the index, since staged changes are the only remaining reason to reject the operation. Conversely, `--allow-staged` checks only the working tree. The existing full scan remains when neither flag is passed, and passing both flags still skips the scan entirely. Git's intent-to-add entries are explicitly classified as dirty rather than staged, so `git add --intent-to-add` cannot accidentally bypass the working-tree protection.

For compiler diagnostics, discover the sysroot only when a suggested file path is absolute. Relative project paths cannot lie under an absolute sysroot, while absolute paths remain subject to the existing sysroot and Cargo-registry protections.

In prior measurements using separately built release binaries, a no-op on a warmed `uv-small-str` checkout with `--allow-dirty` improved from **222 ± 13 ms to 195 ± 14 ms** across 25 runs. On a separate synthetic single-fix fixture with `--allow-no-vcs`, skipping sysroot discovery improved runtime from **288 ± 33 ms to 263 ± 21 ms** across 35 runs.
