### PR TITLE
Fix denied warnings with encoded compiler flags

### DIFF
--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -282,13 +282,21 @@ fn check(args: &FixitArgs, lint_cap: &mut bool) -> CargoResult<(Vec<CheckOutput>
 
 /// Applies the original lint cap while preserving existing compiler flags.
 fn cap_lints(command: &mut std::process::Command) {
-    command.env(
-        "RUSTFLAGS",
-        format!(
-            "--cap-lints=warn {}",
-            env::var("RUSTFLAGS").unwrap_or("".to_owned())
-        ),
-    );
+    if let Ok(flags) = env::var("CARGO_ENCODED_RUSTFLAGS") {
+        let separator = if flags.is_empty() { "" } else { "\u{1f}" };
+        command.env(
+            "CARGO_ENCODED_RUSTFLAGS",
+            format!("{flags}{separator}--cap-lints=warn"),
+        );
+    } else {
+        command.env(
+            "RUSTFLAGS",
+            format!(
+                "--cap-lints=warn {}",
+                env::var("RUSTFLAGS").unwrap_or("".to_owned())
+            ),
+        );
+    }
 }
 
 fn denied_lint(messages: &[CheckOutput]) -> bool {

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -40,6 +40,61 @@ fn basic() {
 }
 
 #[cargo_test]
+fn fixes_denied_warnings_with_encoded_rustflags() {
+    let p = denied_warnings_project();
+
+    p.cargo_("fixit --allow-no-vcs")
+        .env("CARGO_ENCODED_RUSTFLAGS", "--cfg\u{1f}fixit_test")
+        .run();
+
+    assert!(!p.read_file("src/lib.rs").contains("let mut value"));
+}
+
+#[cargo_test]
+fn clippy_fixes_denied_warnings_with_encoded_rustflags() {
+    let p = denied_warnings_project();
+
+    p.cargo_("fixit --clippy --allow-no-vcs")
+        .env("CARGO_ENCODED_RUSTFLAGS", "--cfg\u{1f}fixit_test")
+        .run();
+
+    assert!(!p.read_file("src/lib.rs").contains("let mut value"));
+}
+
+#[cargo_test]
+fn fixes_denied_warnings_with_empty_encoded_rustflags() {
+    let p = denied_warnings_project();
+
+    p.cargo_("fixit --allow-no-vcs")
+        .env("CARGO_ENCODED_RUSTFLAGS", "")
+        .run();
+
+    assert!(!p.read_file("src/lib.rs").contains("let mut value"));
+}
+
+#[cargo_test]
+fn preserves_explicit_encoded_lint_caps() {
+    let p = denied_warnings_project();
+
+    p.cargo_("fixit --allow-no-vcs")
+        .env("CARGO_ENCODED_RUSTFLAGS", "--cap-lints=deny")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] could not compile")
+        .run();
+
+    assert!(p.read_file("src/lib.rs").contains("let mut value"));
+}
+
+fn denied_warnings_project() -> Project {
+    project()
+        .file(
+            "src/lib.rs",
+            "#![deny(warnings)]\npub fn a() { let mut value = 1; let _ = value; }\n",
+        )
+        .build()
+}
+
+#[cargo_test]
 fn preserves_workspace_fingerprints_without_denied_warnings() {
     let p = project()
         .file(


### PR DESCRIPTION
## Summary

We currently add `--cap-lints=warn` through `RUSTFLAGS` so denied warnings can still be fixed. But Cargo ignores `RUSTFLAGS` whenever `CARGO_ENCODED_RUSTFLAGS` is set, even when its value is empty, causing compiler and Clippy fixes to fail instead.

When encoded flags are present, append the lint cap to `CARGO_ENCODED_RUSTFLAGS` instead. Preserve existing encoded arguments and explicitly configured lint caps, and handle empty encoded values without introducing an empty compiler argument.
