### PR TITLE
Fix empty intent-to-add files with --allow-staged

### DIFF
--- a/src/util/vcs.rs
+++ b/src/util/vcs.rs
@@ -54,8 +54,6 @@ impl VcsOpts {
         repo_opts.include_untracked(true);
         if self.allow_dirty {
             repo_opts.show(git2::StatusShow::Index);
-        } else if self.allow_staged {
-            repo_opts.show(git2::StatusShow::Workdir);
         }
         for status in repo.statuses(Some(&mut repo_opts))?.iter() {
             if let Some(path) = status.path() {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -978,15 +978,11 @@ fn warns_about_intent_to_add_working_directory() {
             .run();
 
         for args in ["fix", "fix --allow-staged"] {
-            if name == "empty" && args == "fix --allow-staged" {
-                project.cargo_(args).run();
-            } else {
-                project
-                    .cargo_(args)
-                    .with_status(101)
-                    .with_stderr_contains("  * src/new.rs (dirty)")
-                    .run();
-            }
+            project
+                .cargo_(args)
+                .with_status(101)
+                .with_stderr_contains("  * src/new.rs (dirty)")
+                .run();
         }
 
         project.cargo_("fix --allow-dirty").run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -967,24 +967,30 @@ fn warns_about_staged_working_directory() {
 
 #[cargo_test]
 fn warns_about_intent_to_add_working_directory() {
-    let project = git::new("foo", |project| {
-        project.file("src/lib.rs", "pub fn foo() {}")
-    });
-    project.change_file("src/new.rs", "pub fn new() {}");
-    project
-        .process("git")
-        .args(&["add", "--intent-to-add", "src/new.rs"])
-        .run();
-
-    for args in ["fix", "fix --allow-staged"] {
+    for (name, contents) in [("empty", ""), ("nonempty", "pub fn new() {}")] {
+        let project = git::new(name, |project| {
+            project.file("src/lib.rs", "pub fn foo() {}")
+        });
+        project.change_file("src/new.rs", contents);
         project
-            .cargo_(args)
-            .with_status(101)
-            .with_stderr_contains("  * src/new.rs (dirty)")
+            .process("git")
+            .args(&["add", "--intent-to-add", "src/new.rs"])
             .run();
-    }
 
-    project.cargo_("fix --allow-dirty").run();
+        for args in ["fix", "fix --allow-staged"] {
+            if name == "empty" && args == "fix --allow-staged" {
+                project.cargo_(args).run();
+            } else {
+                project
+                    .cargo_(args)
+                    .with_status(101)
+                    .with_stderr_contains("  * src/new.rs (dirty)")
+                    .run();
+            }
+        }
+
+        project.cargo_("fix --allow-dirty").run();
+    }
 }
 
 #[cargo_test]


### PR DESCRIPTION
## Summary

When a file is marked intent-to-add with `git add -N`, Git records an empty placeholder in the index. If the file itself is also empty, `--allow-staged` sees no difference between the index and working tree, overlooks the unstaged file, and incorrectly allows fixes to proceed.

Inspect both the index and working tree when staged changes are allowed so empty intent-to-add entries are correctly identified as dirty. Preserve the index-only fast path for `--allow-dirty` and cover both empty and nonempty intent-to-add files.

This edge case also affects upstream `cargo fix --allow-staged`.
