### PR TITLE
Restore files after interrupted fixes

### DIFF
--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -476,15 +476,13 @@ fn fix_errors(
         }
         if fixed.modified() {
             let new_source = fixed.finish()?;
+            let file_state = files.entry(file.clone()).or_insert(File {
+                fixes: 0,
+                original_source: source,
+            });
             paths::write(&file, new_source)?;
             made_changes = true;
-            files
-                .entry(file)
-                .or_insert(File {
-                    fixes: 0,
-                    original_source: source,
-                })
-                .fixes += num_fixes;
+            file_state.fixes += num_fixes;
         }
     }
 

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -60,6 +60,22 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
     args.vcs_opts.valid_vcs()?;
 
+    let mut active_targets = IndexMap::new();
+    match fix(&args, &mut active_targets) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            for (file, original) in active_targets.values().flat_map(|files| files.iter()) {
+                paths::write(file, &original.original_source)?;
+            }
+            Err(error)
+        }
+    }
+}
+
+fn fix(
+    args: &FixitArgs,
+    active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+) -> CargoResult<()> {
     let max_iterations: usize = env::var("CARGO_FIX_MAX_RETRIES")
         .ok()
         .and_then(|i| i.parse().ok())
@@ -69,13 +85,12 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
     let mut last_errors = IndexMap::new();
     let mut current_target: Option<BuildUnit> = None;
-    let mut active_targets: IndexMap<BuildUnit, IndexMap<String, File>> = IndexMap::new();
     let mut seen = HashSet::new();
 
     loop {
         trace!("iteration={iteration}");
         trace!("current_target={current_target:?}");
-        let (messages, exit_code) = check(&args, &mut lint_cap)?;
+        let (messages, exit_code) = check(args, &mut lint_cap)?;
 
         if !args.broken_code && exit_code != Some(0) {
             let mut out = String::new();
@@ -99,6 +114,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                     shell::note(format!("reverting `{file}` to its original state"))?;
                     paths::write(file, original_source)?;
                 }
+                active_targets.clear();
                 out.push('\n');
 
                 out.push_str(&gen_please_report_this_bug_text(args.clippy));
@@ -118,7 +134,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                     out.push_str(&format!("{}\n\n", e.trim_end()));
                 }
 
-                let (messages, _) = check(&args, &mut lint_cap)?;
+                let (messages, _) = check(args, &mut lint_cap)?;
                 let mut errors = messages
                     .into_iter()
                     .filter_map(|e| match e {
@@ -162,7 +178,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                             .filter_map(|(_, diagnostic)| diagnostic.clone()),
                     );
                 }
-                finish_target(target, &mut active_targets, &mut errors, &mut seen)?;
+                finish_target(target, active_targets, &mut errors, &mut seen)?;
                 current_target = None;
                 iteration = 0;
             } else {
@@ -175,7 +191,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
             if build_unit_map.get(target).is_none_or(IndexMap::is_empty) {
                 let target = current_target.take().expect("current target is present");
                 build_unit_map.shift_remove(&target);
-                finish_target(target, &mut active_targets, &mut errors, &mut seen)?;
+                finish_target(target, active_targets, &mut errors, &mut seen)?;
                 iteration = 0;
                 finalized_target = true;
             }
@@ -226,7 +242,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
         if !made_changes {
             if let Some(pkg) = current_target {
-                finish_target(pkg, &mut active_targets, &mut last_errors, &mut seen)?;
+                finish_target(pkg, active_targets, &mut last_errors, &mut seen)?;
                 current_target = None;
                 iteration = 0;
                 continue;
@@ -235,7 +251,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
         }
     }
 
-    for files in active_targets.into_values() {
+    for files in active_targets.values() {
         for (name, file) in files {
             shell::fixed(name, file.fixes)?;
         }
@@ -245,6 +261,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
         shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
     }
 
+    active_targets.clear();
     Ok(())
 }
 
@@ -262,14 +279,18 @@ fn finish_target(
         shell::status("Checking", format_package_id(&target.package_id)?)?;
     }
 
-    for (name, file) in active_targets.shift_remove(&target).unwrap_or_default() {
-        shell::fixed(name, file.fixes)?;
+    if let Some(files) = active_targets.get(&target) {
+        for (name, file) in files {
+            shell::fixed(name, file.fixes)?;
+        }
     }
 
-    for error in errors.shift_remove(&target).unwrap_or_default() {
+    for error in errors.get(&target).into_iter().flatten() {
         shell::print_ansi_stderr(format!("{}\n\n", error.trim_end()).as_bytes())?;
     }
 
+    active_targets.shift_remove(&target);
+    errors.shift_remove(&target);
     seen.insert(target);
     Ok(())
 }

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -60,8 +60,6 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
     args.vcs_opts.valid_vcs()?;
 
-    let mut files: IndexMap<String, File> = IndexMap::new();
-
     let max_iterations: usize = env::var("CARGO_FIX_MAX_RETRIES")
         .ok()
         .and_then(|i| i.parse().ok())
@@ -71,6 +69,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
     let mut last_errors = IndexMap::new();
     let mut current_target: Option<BuildUnit> = None;
+    let mut active_targets: IndexMap<BuildUnit, IndexMap<String, File>> = IndexMap::new();
     let mut seen = HashSet::new();
 
     loop {
@@ -94,7 +93,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                         fixes: _,
                         original_source,
                     },
-                ) in &files
+                ) in active_targets.values().flat_map(|files| files.iter())
                 {
                     out.push_str(&format!("  * {file}\n"));
                     shell::note(format!("reverting `{file}` to its original state"))?;
@@ -163,7 +162,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                             .filter_map(|(_, diagnostic)| diagnostic.clone()),
                     );
                 }
-                finish_target(target, &mut files, &mut errors, &mut seen)?;
+                finish_target(target, &mut active_targets, &mut errors, &mut seen)?;
                 current_target = None;
                 iteration = 0;
             } else {
@@ -176,7 +175,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
             if build_unit_map.get(target).is_none_or(IndexMap::is_empty) {
                 let target = current_target.take().expect("current target is present");
                 build_unit_map.shift_remove(&target);
-                finish_target(target, &mut files, &mut errors, &mut seen)?;
+                finish_target(target, &mut active_targets, &mut errors, &mut seen)?;
                 iteration = 0;
                 finalized_target = true;
             }
@@ -208,10 +207,14 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
                 seen.insert(build_unit);
             } else if !file_map.is_empty()
                 && current_target.get_or_insert(build_unit.clone()) == &build_unit
-                && fix_errors(&mut files, file_map, build_unit_errors)?
             {
-                made_changes = true;
-                break;
+                let target_files = active_targets.entry(build_unit.clone()).or_default();
+                if fix_errors(target_files, file_map, build_unit_errors)? {
+                    made_changes = true;
+                    break;
+                } else if target_files.is_empty() {
+                    active_targets.shift_remove(&build_unit);
+                }
             }
         }
 
@@ -223,7 +226,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
         if !made_changes {
             if let Some(pkg) = current_target {
-                finish_target(pkg, &mut files, &mut last_errors, &mut seen)?;
+                finish_target(pkg, &mut active_targets, &mut last_errors, &mut seen)?;
                 current_target = None;
                 iteration = 0;
                 continue;
@@ -232,8 +235,10 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
         }
     }
 
-    for (name, file) in files {
-        shell::fixed(name, file.fixes)?;
+    for files in active_targets.into_values() {
+        for (name, file) in files {
+            shell::fixed(name, file.fixes)?;
+        }
     }
 
     for e in last_errors.iter().flat_map(|(_, e)| e) {
@@ -246,7 +251,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 /// Marks a target complete after reporting its fixes and remaining diagnostics.
 fn finish_target(
     target: BuildUnit,
-    files: &mut IndexMap<String, File>,
+    active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
     errors: &mut IndexMap<BuildUnit, IndexSet<String>>,
     seen: &mut HashSet<BuildUnit>,
 ) -> CargoResult<()> {
@@ -257,7 +262,7 @@ fn finish_target(
         shell::status("Checking", format_package_id(&target.package_id)?)?;
     }
 
-    for (name, file) in std::mem::take(files) {
+    for (name, file) in active_targets.shift_remove(&target).unwrap_or_default() {
         shell::fixed(name, file.fixes)?;
     }
 

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -119,13 +119,13 @@ fn preserves_workspace_fingerprints_without_denied_warnings() {
 
     p.cargo_("check").run();
 
-    let fingerprints_before = package_fingerprints(&p, &["foo-", "cached-dependency-"]);
+    let fingerprints_before = package_fingerprints(&p, &["foo", "cached-dependency"]);
     assert_eq!(fingerprints_before.len(), 2);
 
     p.cargo_("fixit --allow-no-vcs").run();
 
     assert_eq!(
-        package_fingerprints(&p, &["foo-", "cached-dependency-"]),
+        package_fingerprints(&p, &["foo", "cached-dependency"]),
         fingerprints_before
     );
 }
@@ -157,13 +157,13 @@ fn clippy_preserves_workspace_fingerprints_without_denied_warnings() {
 
     p.cargo_("clippy --workspace").run();
 
-    let fingerprints_before = package_fingerprints(&p, &["app-", "cached-dependency-"]);
+    let fingerprints_before = package_fingerprints(&p, &["app", "cached-dependency"]);
     assert_eq!(fingerprints_before.len(), 2);
 
     p.cargo_("fixit --clippy --workspace --allow-no-vcs").run();
 
     assert_eq!(
-        package_fingerprints(&p, &["app-", "cached-dependency-"]),
+        package_fingerprints(&p, &["app", "cached-dependency"]),
         fingerprints_before
     );
 }
@@ -199,27 +199,33 @@ fn fixes_denied_lints_with_compiler_error_codes() {
 }
 
 fn package_fingerprints(project: &Project, packages: &[&str]) -> Vec<(String, Vec<u8>)> {
-    let mut fingerprints = std::fs::read_dir(project.build_dir().join("debug/.fingerprint"))
-        .unwrap()
-        .map(Result::unwrap)
-        .filter(|entry| {
-            let name = entry.file_name();
-            packages
-                .iter()
-                .any(|package| name.to_string_lossy().starts_with(package))
-        })
-        .map(|entry| {
-            let dep_info = std::fs::read_dir(entry.path())
-                .unwrap()
-                .map(Result::unwrap)
-                .find(|file| file.file_name().to_string_lossy().starts_with("dep-lib-"))
-                .unwrap();
-            (
-                entry.file_name().to_string_lossy().into_owned(),
-                std::fs::read(dep_info.path()).unwrap(),
-            )
-        })
+    let root = project.build_dir().join("debug");
+    let dep_infos = packages
+        .iter()
+        .map(|package| format!("dep-lib-{}", package.replace('-', "_")))
         .collect::<Vec<_>>();
+    let mut directories = vec![root.clone()];
+    let mut fingerprints = Vec::new();
+
+    while let Some(directory) = directories.pop() {
+        for entry in std::fs::read_dir(directory).unwrap().map(Result::unwrap) {
+            if entry.file_type().unwrap().is_dir() {
+                directories.push(entry.path());
+            } else if dep_infos
+                .iter()
+                .any(|dep_info| entry.file_name() == std::ffi::OsStr::new(dep_info))
+            {
+                let path = entry.path();
+                fingerprints.push((
+                    path.strip_prefix(&root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .into_owned(),
+                    std::fs::read(path).unwrap(),
+                ));
+            }
+        }
+    }
     fingerprints.sort_unstable();
     fingerprints
 }

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -284,7 +284,7 @@ fn fixable_and_unfixable() {
 
 #[cfg(unix)]
 #[cargo_test]
-fn retains_prior_writes_when_later_write_fails() {
+fn restores_prior_writes_when_later_write_fails() {
     use std::os::unix::fs::PermissionsExt;
 
     let original_lib = "mod module;\npub fn lib() { let mut value = 1; let _ = value; }\n";
@@ -308,10 +308,7 @@ fn retains_prior_writes_when_later_write_fails() {
 
     std::fs::set_permissions(&unwritable, std::fs::Permissions::from_mode(0o644)).unwrap();
     assert_eq!(p.read_file("src/lib.rs"), original_lib);
-    assert_eq!(
-        p.read_file("src/module.rs"),
-        "pub fn module() { let value = 1; let _ = value; }\n"
-    );
+    assert_eq!(p.read_file("src/module.rs"), original_module);
 }
 
 #[cfg(unix)]

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -282,6 +282,80 @@ fn fixable_and_unfixable() {
     );
 }
 
+#[cfg(unix)]
+#[cargo_test]
+fn retains_prior_writes_when_later_write_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let original_lib = "mod module;\npub fn lib() { let mut value = 1; let _ = value; }\n";
+    let original_module = "pub fn module() { let mut value = 1; let _ = value; }\n";
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/lib.rs", original_lib)
+        .file("src/module.rs", original_module)
+        .build();
+
+    let unwritable = p.root().join("src/lib.rs");
+    std::fs::set_permissions(&unwritable, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+    p.cargo_("fixit --allow-no-vcs")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] failed to write `src/lib.rs`: [..]
+
+"#]])
+        .run();
+
+    std::fs::set_permissions(&unwritable, std::fs::Permissions::from_mode(0o644)).unwrap();
+    assert_eq!(p.read_file("src/lib.rs"), original_lib);
+    assert_eq!(
+        p.read_file("src/module.rs"),
+        "pub fn module() { let value = 1; let _ = value; }\n"
+    );
+}
+
+#[cfg(unix)]
+#[cargo_test]
+fn retains_completed_target_when_later_write_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let original_a = "pub fn a() -> i32 { let mut value = 1; value }\n";
+    let original_b = "pub fn b() -> i32 { let mut value = a::a(); value }\n";
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"a\", \"b\"]\nresolver = \"2\"\n",
+        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
+        .file("a/src/lib.rs", original_a)
+        .file(
+            "b/Cargo.toml",
+            "[package]\nname = \"b\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\na = { path = \"../a\" }\n",
+        )
+        .file("b/src/lib.rs", original_b)
+        .build();
+
+    let unwritable = p.root().join("b/src/lib.rs");
+    std::fs::set_permissions(&unwritable, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+    p.cargo_("fixit --workspace --allow-no-vcs")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/lib.rs (1 fix)
+[ERROR] failed to write `b/src/lib.rs`: [..]
+
+"#]])
+        .run();
+
+    std::fs::set_permissions(&unwritable, std::fs::Permissions::from_mode(0o644)).unwrap();
+    assert_eq!(
+        p.read_file("a/src/lib.rs"),
+        "pub fn a() -> i32 { let value = 1; value }\n"
+    );
+    assert_eq!(p.read_file("b/src/lib.rs"), original_b);
+}
+
 #[cargo_test]
 fn dependency_order() {
     let p = project()


### PR DESCRIPTION
## Summary

Previously, if fix processing returned an internal error after writing one or more files, we could leave behind partial changes. Compiler failures already restored active fixes, but read, write, and reporting failures did not share that rollback path.

This PR records each file's original source before its first write and keeps that state grouped by active build target until finalization succeeds. If processing returns an error, we restore every unfinalized file before returning it.
