### PR TITLE
Add dangerous parallel fixing

### DIFF
--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -35,6 +35,10 @@ pub struct FixitArgs {
     #[arg(long)]
     broken_code: bool,
 
+    /// Fix all targets together, risking stale suggestions
+    #[arg(long = "Zdangerous-parallel-fixes")]
+    dangerous_parallel_fixes: bool,
+
     #[command(flatten)]
     color: colorchoice_clap::Color,
 
@@ -88,7 +92,11 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
-    let mut package_graph = PackageGraph::load(&args.check_flags);
+    let mut package_graph = if args.dangerous_parallel_fixes {
+        None
+    } else {
+        PackageGraph::load(&args.check_flags)
+    };
     let mut seen = HashSet::new();
 
     loop {
@@ -237,12 +245,12 @@ fn fix(
 
                 seen.insert(build_unit);
             } else if !file_map.is_empty() {
-                if continuing_batch && !active_targets.contains_key(&build_unit) {
+                let was_active = active_targets.contains_key(&build_unit);
+                if continuing_batch && !was_active {
                     continue;
                 }
 
-                let was_active = active_targets.contains_key(&build_unit);
-                if !was_active && !active_targets.is_empty() {
+                if !args.dangerous_parallel_fixes && !was_active && !active_targets.is_empty() {
                     let Some(graph) = package_graph.as_mut() else {
                         continue;
                     };

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -474,6 +474,21 @@ fn dependency_graph_batches_only_independent_packages() {
     let crate_invocations = crate::fix::rustc_invocations(&rustc_log, ["a", "b", "c", "d"]);
     // `c` and `d` share a batch, while `b` and then `a` wait for their dependencies.
     assert_eq!(crate_invocations, [4, 3, 2, 2]);
+
+    for package in ["a", "b", "c", "d"] {
+        p.change_file(format!("{package}/src/lib.rs"), "use std as foo;");
+    }
+    std::fs::remove_dir_all(&rustc_log).unwrap();
+    std::fs::create_dir_all(&rustc_log).unwrap();
+
+    p.cargo_("fixit --allow-no-vcs --Zdangerous-parallel-fixes")
+        .env("RUSTC_WORKSPACE_WRAPPER", crate::fix::echo_wrapper())
+        .env("__CARGO_FIXIT_RUSTC_LOG", &rustc_log)
+        .with_status(0)
+        .run();
+
+    let crate_invocations = crate::fix::rustc_invocations(&rustc_log, ["a", "b", "c", "d"]);
+    assert_eq!(crate_invocations, [2, 2, 2, 2]);
 }
 
 #[cargo_test]

--- a/tests/testsuite/help/stdout.term.svg
+++ b/tests/testsuite/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="886px" height="974px" xmlns="http://www.w3.org/2000/svg">
+<svg width="995px" height="992px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -26,101 +26,103 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      --clippy        Run `clippy` instead of `check`</tspan>
+    <tspan x="10px" y="118px"><tspan>      --clippy                     Run `clippy` instead of `check`</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      --broken-code   Fix code even if it already has compiler errors</tspan>
+    <tspan x="10px" y="136px"><tspan>      --broken-code                Fix code even if it already has compiler errors</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      --color &lt;WHEN&gt;  Controls when to use color [default: auto] [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="154px"><tspan>      --Zdangerous-parallel-fixes  Fix all targets together, risking stale suggestions</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --allow-no-vcs  Fix code even if a VCS was not detected</tspan>
+    <tspan x="10px" y="172px"><tspan>      --color &lt;WHEN&gt;               Controls when to use color [default: auto] [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --allow-dirty   Fix code even if the working directory is dirty or has staged changes</tspan>
+    <tspan x="10px" y="190px"><tspan>      --allow-no-vcs               Fix code even if a VCS was not detected</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --allow-staged  Fix code even if the working directory has staged changes</tspan>
+    <tspan x="10px" y="208px"><tspan>      --allow-dirty                Fix code even if the working directory is dirty or has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -Z &lt;FLAG&gt;           Unstable (nightly-only) flags</tspan>
+    <tspan x="10px" y="226px"><tspan>      --allow-staged               Fix code even if the working directory has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  -h, --help          Print help</tspan>
+    <tspan x="10px" y="244px"><tspan>  -Z &lt;FLAG&gt;                        Unstable (nightly-only) flags</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  -V, --version       Print version</tspan>
+    <tspan x="10px" y="262px"><tspan>  -h, --help                       Print help</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan>  -V, --version                    Print version</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>Package Selection:</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  -p, --package &lt;SPEC&gt;  Package(s) to fix</tspan>
+    <tspan x="10px" y="316px"><tspan>Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
+    <tspan x="10px" y="334px"><tspan>  -p, --package &lt;SPEC&gt;  Package(s) to fix</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
+    <tspan x="10px" y="352px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="370px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>Target Selection:</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      --lib             Fix only this package's library</tspan>
+    <tspan x="10px" y="424px"><tspan>Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      --bins            Fix all binaries</tspan>
+    <tspan x="10px" y="442px"><tspan>      --lib             Fix only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
+    <tspan x="10px" y="460px"><tspan>      --bins            Fix all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      --examples        Fix all examples</tspan>
+    <tspan x="10px" y="478px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
+    <tspan x="10px" y="496px"><tspan>      --examples        Fix all examples</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      --tests           Fix all tests</tspan>
+    <tspan x="10px" y="514px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
+    <tspan x="10px" y="532px"><tspan>      --tests           Fix all tests</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      --benches         Fix all benches</tspan>
+    <tspan x="10px" y="550px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
+    <tspan x="10px" y="568px"><tspan>      --benches         Fix all benches</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      --all-targets     Fix all targets</tspan>
+    <tspan x="10px" y="586px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>      --all-targets     Fix all targets</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>Feature Selection:</tspan>
+    <tspan x="10px" y="622px">
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="640px"><tspan>Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      --all-features         Activate all available features</tspan>
+    <tspan x="10px" y="658px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="676px"><tspan>      --all-features         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="694px">
+    <tspan x="10px" y="694px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>Compilation Options:</tspan>
+    <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      --jobs &lt;N&gt;                Number of parallel jobs, defaults to # of CPUs</tspan>
+    <tspan x="10px" y="730px"><tspan>Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      --release                 Fix artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="748px"><tspan>      --jobs &lt;N&gt;                Number of parallel jobs, defaults to # of CPUs</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      --profile &lt;PROFILE-NAME&gt;  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="766px"><tspan>      --release                 Fix artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      --target &lt;TRIPLE&gt;         Fix for the target triple</tspan>
+    <tspan x="10px" y="784px"><tspan>      --profile &lt;PROFILE-NAME&gt;  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      --target-dir &lt;DIRECTORY&gt;  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="802px"><tspan>      --target &lt;TRIPLE&gt;         Fix for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="820px">
+    <tspan x="10px" y="820px"><tspan>      --target-dir &lt;DIRECTORY&gt;  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan>Manifest Options:</tspan>
+    <tspan x="10px" y="838px">
 </tspan>
-    <tspan x="10px" y="856px"><tspan>      --manifest-path &lt;PATH&gt;  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="856px"><tspan>Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      --lockfile-path &lt;PATH&gt;  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="874px"><tspan>      --manifest-path &lt;PATH&gt;  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      --ignore-rust-version   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="892px"><tspan>      --lockfile-path &lt;PATH&gt;  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      --locked                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="910px"><tspan>      --ignore-rust-version   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      --offline               Run without accessing the network</tspan>
+    <tspan x="10px" y="928px"><tspan>      --locked                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      --frozen                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="946px"><tspan>      --offline               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="964px">
+    <tspan x="10px" y="964px"><tspan>      --frozen                Equivalent to specifying both --locked and --offline</tspan>
+</tspan>
+    <tspan x="10px" y="982px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary

By default, we keep dependency-related packages in separate fix batches so each downstream package receives fresh diagnostics after its dependencies change.

This PR adds `--Zdangerous-parallel-fixes` to apply every compatible fix from the same compiler snapshot together. This can improve performance for dependency-heavy workspaces, at the risk of applying stale suggestions when an earlier fix changes a downstream diagnostic.

On a warm workspace with a ten-package linear dependency chain, release-binary runtime across 10 runs improves from 3.475 s +/- 0.355 s to 1.084 s +/- 0.140 s (3.21x), with ranges of 3.067-4.214 s and 980 ms-1.465 s.
