### PR TITLE
Load package metadata lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Performance
 
-- Batch parallel packages with non-overlappin fixes
+- Batch parallel packages with non-overlapping fixes
 
 ### Fixes
 

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -92,11 +92,7 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
-    let mut package_graph = if args.dangerous_parallel_fixes {
-        None
-    } else {
-        PackageGraph::load(&args.check_flags)
-    };
+    let mut package_graph_cache: Option<Option<PackageGraph>> = None;
     let mut seen = HashSet::new();
 
     loop {
@@ -251,7 +247,17 @@ fn fix(
                 }
 
                 if !args.dangerous_parallel_fixes && !was_active && !active_targets.is_empty() {
-                    let Some(graph) = package_graph.as_mut() else {
+                    if active_targets
+                        .keys()
+                        .any(|active| active.package_id == build_unit.package_id)
+                    {
+                        continue;
+                    }
+
+                    if package_graph_cache.is_none() {
+                        package_graph_cache = Some(PackageGraph::load(&args.check_flags));
+                    }
+                    let Some(Some(graph)) = package_graph_cache.as_mut() else {
                         continue;
                     };
 

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -41,6 +41,41 @@ fn basic() {
 }
 
 #[cargo_test]
+fn single_package_loads_dependency_metadata() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            "pub fn sample() { let mut value = 1; let _ = value; }\n",
+        )
+        .file(
+            "src/main.rs",
+            "fn main() { let mut value = 1; let _ = value; }\n",
+        )
+        .build();
+
+    let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+    command.cwd(p.root());
+    command.arg("fixit");
+    command.arg("--allow-no-vcs");
+    command.env("CARGO", p.root().join("metadata-must-not-run"));
+    command.env("FIXIT_LOG", "cargo_fixit=warn");
+
+    cargo_test_support::execs()
+        .with_process_builder(command)
+        .with_stderr_data(str![[r#"
+[..] WARN cargo_fixit::ops::fixit: failed to run `cargo metadata`: [..]
+[CHECKING] foo v0.0.1
+[FIXED] src/lib.rs (1 fix)
+[FIXED] src/main.rs (1 fix)
+
+"#]])
+        .run();
+
+    assert!(!p.read_file("src/lib.rs").contains("let mut value"));
+    assert!(!p.read_file("src/main.rs").contains("let mut value"));
+}
+
+#[cargo_test]
 fn fixes_denied_warnings_with_encoded_rustflags() {
     let p = denied_warnings_project();
 

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -41,7 +41,7 @@ fn basic() {
 }
 
 #[cargo_test]
-fn single_package_loads_dependency_metadata() {
+fn single_package_skips_dependency_metadata() {
     let p = project()
         .file(
             "src/lib.rs",
@@ -63,7 +63,6 @@ fn single_package_loads_dependency_metadata() {
     cargo_test_support::execs()
         .with_process_builder(command)
         .with_stderr_data(str![[r#"
-[..] WARN cargo_fixit::ops::fixit: failed to run `cargo metadata`: [..]
 [CHECKING] foo v0.0.1
 [FIXED] src/lib.rs (1 fix)
 [FIXED] src/main.rs (1 fix)


### PR DESCRIPTION
Previously, every `cargo fixit` invocation ran `cargo metadata` before its first compiler check so dependency-related packages could be kept in separate fix batches. Clean runs and fixes confined to one package never consult the package graph, so this added a subprocess to the common path without affecting scheduling.

This PR loads dependency metadata only when a second package is eligible to join an active batch. Same-package targets are rejected before loading metadata, and both successful and failed loads are cached for the rest of the run.

The following timings were measured over uv:

| Command | Clean: 1 package | Clean: 5 packages | Fix: 1 package | Fix: 5 packages |
| --- | ---: | ---: | ---: | ---: |
| `cargo clippy` | 139 ms | 158 ms | 199 ms | 360 ms |
| `cargo clippy --fix` | 273 ms | 656 ms | 581 ms | 1,150 ms |
| `cargo fixit` 0.1.7 | 154 ms | 163 ms | 843 ms | 3,102 ms |
| `cargo fixit` 0.1.9 | 512 ms | 462 ms | 758 ms | 1,287 ms |
| This PR (patched 0.1.9) | 160 ms | 165 ms | 443 ms | 1,296 ms |
| This PR with `--Zdangerous-parallel-fixes` | — | 168 ms | — | 809 ms |
