### PR TITLE
Avoid resolving external dependencies for workspace fix batches

### DIFF
--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -347,7 +347,7 @@ fn fix(
     Ok(())
 }
 
-/// Resolved package dependencies used to batch only transitively unrelated packages.
+/// Package dependencies used to batch only transitively unrelated packages.
 #[derive(Debug)]
 struct PackageGraph {
     dependencies: HashMap<String, Vec<String>>,
@@ -357,6 +357,70 @@ struct PackageGraph {
 impl PackageGraph {
     /// Loads the package graph, returning `None` when batching must remain serial.
     fn load(flags: &CheckFlags) -> Option<Self> {
+        let mut command = MetadataCommand::new();
+        command.no_deps();
+        command.other_options(flags.to_metadata_flags());
+
+        let metadata = match command.exec() {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                warn!("failed to run `cargo metadata`: {error}");
+                return None;
+            }
+        };
+
+        // A script is identified by its manifest path, not its containing directory.
+        if metadata
+            .packages
+            .iter()
+            .any(|package| package.manifest_path.file_name() != Some("Cargo.toml"))
+        {
+            return Self::load_resolved(flags);
+        }
+
+        let package_ids_by_path: HashMap<_, _> = metadata
+            .packages
+            .iter()
+            .filter_map(|package| {
+                package
+                    .manifest_path
+                    .parent()
+                    .map(|path| (path, package.id.repr.as_str()))
+            })
+            .collect();
+        if package_ids_by_path.len() != metadata.packages.len() {
+            return Self::load_resolved(flags);
+        }
+
+        let package_names: HashSet<_> = metadata
+            .packages
+            .iter()
+            .map(|package| package.name.as_ref())
+            .collect();
+        let mut dependencies = HashMap::with_capacity(metadata.packages.len());
+        for package in &metadata.packages {
+            let mut package_dependencies = Vec::new();
+            for dependency in &package.dependencies {
+                if let Some(path) = &dependency.path {
+                    let Some(dependency_id) = package_ids_by_path.get(path.as_path()) else {
+                        return Self::load_resolved(flags);
+                    };
+                    package_dependencies.push((*dependency_id).to_owned());
+                } else if package_names.contains(dependency.name.as_str()) {
+                    return Self::load_resolved(flags);
+                }
+            }
+            dependencies.insert(package.id.repr.clone(), package_dependencies);
+        }
+
+        Some(Self {
+            dependencies,
+            reachable: HashMap::new(),
+        })
+    }
+
+    /// Resolves external packages when workspace metadata cannot prove independence.
+    fn load_resolved(flags: &CheckFlags) -> Option<Self> {
         let mut command = MetadataCommand::new();
         command.other_options(flags.to_metadata_flags());
 

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -536,7 +536,7 @@ fn dependency_graph_batches_only_independent_packages() {
 
 #[cfg(unix)]
 #[cargo_test]
-fn workspace_dependency_graph_loads_metadata() {
+fn workspace_dependency_graph_uses_unresolved_metadata() {
     use std::os::unix::fs::PermissionsExt;
 
     let p = project()
@@ -558,7 +558,7 @@ fn workspace_dependency_graph_loads_metadata() {
             "metadata-wrapper.sh",
             r#"#!/bin/sh
 printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
-if [ "$1" != metadata ] || [ "$4" = --no-deps ]; then
+if [ "$1" != metadata ] || [ "$4" != --no-deps ]; then
     exit 41
 fi
 exec "$FIXIT_REAL_CARGO" "$@"
@@ -590,7 +590,7 @@ exec "$FIXIT_REAL_CARGO" "$@"
     assert_ui().eq(
         p.read_file("metadata.log").trim_end(),
         str![[r#"
-metadata --format-version 1
+metadata --format-version 1 --no-deps
 "#]],
     );
     assert_eq!(
@@ -663,6 +663,7 @@ exec "$FIXIT_REAL_CARGO" "$@"
     assert_ui().eq(
         p.read_file("metadata.log").trim_end(),
         str![[r#"
+metadata --format-version 1 --no-deps -Z script --manifest-path script.rs
 metadata --format-version 1 -Z script --manifest-path script.rs
 "#]],
     );
@@ -672,7 +673,7 @@ metadata --format-version 1 -Z script --manifest-path script.rs
 
 #[cfg(unix)]
 #[cargo_test]
-fn external_path_dependencies_connect_workspace_members() {
+fn external_path_dependencies_fall_back_to_resolved_metadata() {
     use std::os::unix::fs::PermissionsExt;
 
     let p = project()
@@ -732,6 +733,7 @@ exec "$FIXIT_REAL_CARGO" "$@"
     assert_ui().eq(
         p.read_file("metadata.log").trim_end(),
         str![[r#"
+metadata --format-version 1 --no-deps
 metadata --format-version 1
 "#]],
     );

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -1,7 +1,10 @@
+use cargo_test_support::Project;
+use cargo_test_support::basic_manifest;
 use cargo_test_support::cargo_test;
-use cargo_test_support::{basic_manifest, compare::assert_ui, project, Project};
-use snapbox::str;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::project;
 use snapbox::IntoData as _;
+use snapbox::str;
 
 use crate::fix::FixitProject;
 
@@ -388,9 +391,15 @@ fn independent_workspace_packages() {
             "[workspace]\nmembers = [\"a\", \"b\"]\nresolver = \"2\"\n",
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
-        .file("a/src/lib.rs", "pub fn a() { let mut value = 1; let _ = value; }\n")
+        .file(
+            "a/src/lib.rs",
+            "pub fn a() { let mut value = 1; let _ = value; }\n",
+        )
         .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
-        .file("b/src/lib.rs", "pub fn b() { let mut value = 1; let _ = value; }\n")
+        .file(
+            "b/src/lib.rs",
+            "pub fn b() { let mut value = 1; let _ = value; }\n",
+        )
         .build();
 
     p.cargo_("fixit --workspace --allow-no-vcs")
@@ -523,6 +532,211 @@ fn dependency_graph_batches_only_independent_packages() {
 
     let crate_invocations = crate::fix::rustc_invocations(&rustc_log, ["a", "b", "c", "d"]);
     assert_eq!(crate_invocations, [2, 2, 2, 2]);
+}
+
+#[cfg(unix)]
+#[cargo_test]
+fn workspace_dependency_graph_loads_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = ['a', 'b']\nresolver = '2'\n",
+        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
+        .file(
+            "a/src/lib.rs",
+            "pub fn a() { let mut value = 1; let _ = value; }\n",
+        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
+        .file(
+            "b/src/lib.rs",
+            "pub fn b() { let mut value = 1; let _ = value; }\n",
+        )
+        .file(
+            "metadata-wrapper.sh",
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
+if [ "$1" != metadata ] || [ "$4" = --no-deps ]; then
+    exit 41
+fi
+exec "$FIXIT_REAL_CARGO" "$@"
+"#,
+        )
+        .build();
+
+    let wrapper = p.root().join("metadata-wrapper.sh");
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata_log = p.root().join("metadata.log");
+    let rustc_log = p.root().join("rustc.log");
+    std::fs::create_dir_all(&rustc_log).unwrap();
+
+    p.cargo_("build --workspace").run();
+    let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+    command.cwd(p.root());
+    command.arg("fixit");
+    command.arg("--workspace");
+    command.arg("--allow-no-vcs");
+    command.env("CARGO", &wrapper);
+    command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+    command.env("FIXIT_METADATA_LOG", &metadata_log);
+    command.env("RUSTC_WORKSPACE_WRAPPER", crate::fix::echo_wrapper());
+    command.env("__CARGO_FIXIT_RUSTC_LOG", &rustc_log);
+    cargo_test_support::execs()
+        .with_process_builder(command)
+        .run();
+
+    assert_ui().eq(
+        p.read_file("metadata.log").trim_end(),
+        str![[r#"
+metadata --format-version 1
+"#]],
+    );
+    assert_eq!(
+        crate::fix::rustc_invocations(&rustc_log, ["a", "b"]),
+        [2, 2]
+    );
+}
+
+#[cfg(unix)]
+#[cargo_test(nightly, reason = "-Zscript is unstable")]
+fn cargo_script_falls_back_to_resolved_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("dep", "0.1.0"))
+        .file(
+            "src/lib.rs",
+            "pub fn value() -> usize { let mut value = 1; value }\n",
+        )
+        .file(
+            "script.rs",
+            r#"---cargo
+[package]
+edition = "2024"
+
+[dependencies]
+dep = { path = "." }
+---
+
+fn main() {
+    let mut value = dep::value();
+    let _ = value;
+}
+"#,
+        )
+        .file(
+            "metadata-wrapper.sh",
+            r#"#!/bin/sh
+if [ "$1" = metadata ]; then
+    printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
+fi
+exec "$FIXIT_REAL_CARGO" "$@"
+"#,
+        )
+        .build();
+
+    let wrapper = p.root().join("metadata-wrapper.sh");
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata_log = p.root().join("metadata.log");
+
+    let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+    command.cwd(p.root());
+    command.arg("fixit");
+    command.args(&["-Z", "script"]);
+    command.args(&["--manifest-path", "script.rs"]);
+    command.arg("--allow-no-vcs");
+    command.env(
+        "__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS",
+        "nightly",
+    );
+    command.env("CARGO", &wrapper);
+    command.env("CARGO_ENCODED_RUSTFLAGS", "--cap-lints=warn");
+    command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+    command.env("FIXIT_METADATA_LOG", &metadata_log);
+    command.env("RUSTC_BOOTSTRAP", "1");
+    cargo_test_support::execs()
+        .with_process_builder(command)
+        .run();
+
+    assert_ui().eq(
+        p.read_file("metadata.log").trim_end(),
+        str![[r#"
+metadata --format-version 1 -Z script --manifest-path script.rs
+"#]],
+    );
+    assert!(!p.read_file("src/lib.rs").contains("let mut value"));
+    assert!(!p.read_file("script.rs").contains("let mut value"));
+}
+
+#[cfg(unix)]
+#[cargo_test]
+fn external_path_dependencies_connect_workspace_members() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = ['consumer', 'provider']\nexclude = ['external']\nresolver = '2'\n",
+        )
+        .file(
+            "consumer/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\nexternal = {{ path = '../external' }}\n",
+                basic_manifest("consumer", "0.1.0")
+            ),
+        )
+        .file(
+            "consumer/src/lib.rs",
+            "pub fn consumer() -> usize { let mut value = external::value(); value }\n",
+        )
+        .file(
+            "external/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\nprovider = {{ path = '../provider' }}\n",
+                basic_manifest("external", "0.1.0")
+            ),
+        )
+        .file("external/src/lib.rs", "pub fn value() -> usize { provider::value() }\n")
+        .file("provider/Cargo.toml", &basic_manifest("provider", "0.1.0"))
+        .file(
+            "provider/src/lib.rs",
+            "pub fn value() -> usize { let mut value = 1; value }\n",
+        )
+        .file(
+            "metadata-wrapper.sh",
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
+exec "$FIXIT_REAL_CARGO" "$@"
+"#,
+        )
+        .build();
+
+    let wrapper = p.root().join("metadata-wrapper.sh");
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let metadata_log = p.root().join("metadata.log");
+
+    let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+    command.cwd(p.root());
+    command.arg("fixit");
+    command.arg("--workspace");
+    command.arg("--allow-no-vcs");
+    command.env("CARGO", &wrapper);
+    command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+    command.env("FIXIT_METADATA_LOG", &metadata_log);
+    cargo_test_support::execs()
+        .with_process_builder(command)
+        .run();
+
+    assert_ui().eq(
+        p.read_file("metadata.log").trim_end(),
+        str![[r#"
+metadata --format-version 1
+"#]],
+    );
+    assert!(!p.read_file("consumer/src/lib.rs").contains("let mut value"));
+    assert!(!p.read_file("provider/src/lib.rs").contains("let mut value"));
 }
 
 #[cargo_test]


### PR DESCRIPTION
## Summary

Previously, building the dependency-ordering graph ran fully resolved `cargo metadata`, even though fix batching only needs relationships between workspace packages. On large workspaces, resolving hundreds or thousands of registry and Git packages can cost more than applying the fixes.

This PR first requests `cargo metadata --no-deps` and reconstructs the graph from each workspace package's declared path dependencies. `--no-deps` omits resolved third-party packages, but still includes every workspace member and its direct dependency declarations, so normal intra-workspace dependency chains retain the existing serial ordering.

Full resolution remains necessary only when workspace-only metadata cannot prove those relationships:

- A single-file Cargo script uses its `.rs` file as the manifest. Mapping packages by the manifest's parent directory can confuse the script with a `Cargo.toml` package in the same directory.
- A local path dependency points outside the workspace. An excluded package can depend back on another workspace member, producing a transitive `member A -> excluded package -> member B` edge that `--no-deps` cannot see.
- A registry or Git dependency has the same package name as a workspace member. A source override can resolve that dependency to the local member even though the unresolved declaration has no path.
- Cargo reports incomplete or duplicate workspace manifest paths.

In those cases, we retry ordinary `cargo metadata` and preserve the existing fully resolved graph. These cases are uncommon in practice: uv, Codex, Ruff, cargo-fixit, and Hawk had zero fallback cases across 1,795 declared local dependency edges.

Measured with release binaries and Rust/Cargo 1.97.1:

| Workspace | Full metadata | Workspace-only metadata | Five-package fixes before | Five-package fixes after |
| --------- | ------------: | ----------------------: | ------------------------: | -----------------------: |
| Codex     |        454 ms |                   36 ms |                  1,655 ms |                 1,253 ms |
| uv        |        208 ms |                   21 ms |                  1,542 ms |                 1,330 ms |

The full test suite passes, including coverage for the workspace-only fast path, Cargo-script fallback, and excluded-path fallback.
