### PR TITLE
Forward non-metadata Cargo commands in metadata tests

### DIFF
--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -628,9 +628,11 @@ fn workspace_dependency_graph_uses_unresolved_metadata() {
         .file(
             "metadata-wrapper.sh",
             r#"#!/bin/sh
-printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
-if [ "$1" != metadata ] || [ "$4" != --no-deps ]; then
-    exit 41
+if [ "$1" = metadata ]; then
+    printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
+    if [ "$4" != --no-deps ]; then
+        exit 41
+    fi
 fi
 exec "$FIXIT_REAL_CARGO" "$@"
 "#,
@@ -779,7 +781,9 @@ fn external_path_dependencies_fall_back_to_resolved_metadata() {
         .file(
             "metadata-wrapper.sh",
             r#"#!/bin/sh
-printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
+if [ "$1" = metadata ]; then
+    printf '%s\n' "$*" >> "$FIXIT_METADATA_LOG"
+fi
 exec "$FIXIT_REAL_CARGO" "$@"
 "#,
         )


### PR DESCRIPTION
## Summary

PR #141 made runtime Cargo selection apply uniformly to compiler checks and metadata queries. The metadata tests from PR #140 still treated every invocation of their `CARGO` wrapper as a metadata query, causing the combined changes to fail on main.

This PR limits the wrappers' logging and validation to `cargo metadata`, while forwarding `cargo check` and other commands unchanged.
