### PR TITLE
Limit fixes to selected packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "clap-cargo",
  "colorchoice-clap",
  "git2",
+ "glob",
  "indexmap",
  "log",
  "rustfix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ indexmap = "2.14.0"
 anstream = "1.0.0"
 log = "0.4.33"
 git2 = "0.20.4"
+glob = "0.3.3"
 cargo-util-schemas = "0.10.1"
 colorchoice-clap = "1.0.8"
 

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 
+use cargo_metadata::Metadata;
 use cargo_metadata::MetadataCommand;
 use cargo_util::paths;
 use clap::Parser;
@@ -92,6 +93,7 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
+    let mut package_metadata_cache: Option<Option<Metadata>> = None;
     let mut package_graph_cache: Option<Option<PackageGraph>> = None;
     let mut seen = HashSet::new();
 
@@ -255,7 +257,12 @@ fn fix(
                     }
 
                     if package_graph_cache.is_none() {
-                        package_graph_cache = Some(PackageGraph::load(&args.check_flags));
+                        package_graph_cache = Some(
+                            package_metadata(&mut package_metadata_cache, &args.check_flags)
+                                .and_then(|metadata| {
+                                    PackageGraph::load(metadata, &args.check_flags)
+                                }),
+                        );
                     }
                     let Some(Some(graph)) = package_graph_cache.as_mut() else {
                         continue;
@@ -347,6 +354,27 @@ fn fix(
     Ok(())
 }
 
+/// Loads unresolved package metadata once, caching failed attempts.
+fn package_metadata<'a>(
+    cache: &'a mut Option<Option<Metadata>>,
+    flags: &CheckFlags,
+) -> Option<&'a Metadata> {
+    cache
+        .get_or_insert_with(|| {
+            let mut command = MetadataCommand::new();
+            command.no_deps();
+            command.other_options(flags.to_metadata_flags());
+            match command.exec() {
+                Ok(metadata) => Some(metadata),
+                Err(error) => {
+                    warn!("failed to run `cargo metadata`: {error}");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
 /// Package dependencies used to batch only transitively unrelated packages.
 #[derive(Debug)]
 struct PackageGraph {
@@ -356,19 +384,7 @@ struct PackageGraph {
 
 impl PackageGraph {
     /// Loads the package graph, returning `None` when batching must remain serial.
-    fn load(flags: &CheckFlags) -> Option<Self> {
-        let mut command = MetadataCommand::new();
-        command.no_deps();
-        command.other_options(flags.to_metadata_flags());
-
-        let metadata = match command.exec() {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                warn!("failed to run `cargo metadata`: {error}");
-                return None;
-            }
-        };
-
+    fn load(metadata: &Metadata, flags: &CheckFlags) -> Option<Self> {
         // A script is identified by its manifest path, not its containing directory.
         if metadata
             .packages

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -8,14 +8,17 @@ use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 
+use anyhow::Context;
 use cargo_metadata::Metadata;
 use cargo_metadata::MetadataCommand;
 use cargo_util::paths;
+use cargo_util_schemas::core::PackageIdSpec;
 use clap::Parser;
 use indexmap::{IndexMap, IndexSet};
 use rustfix::{collect_suggestions, CodeFix, Suggestion};
 use tracing::{trace, warn};
 
+use crate::util::cli::PackageSelection;
 use crate::{
     core::{shell, sysroot::get_sysroot},
     ops::check::{BuildUnit, CheckOutput, DiagnosticLevel, Message, MessageDiagnostic},
@@ -97,7 +100,8 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
-    let mut package_metadata_cache: Option<Option<Metadata>> = None;
+    let mut package_metadata_cache = None;
+    let mut primary_packages_cache = None;
     let mut package_graph_cache: Option<Option<PackageGraph>> = None;
     let mut seen = HashSet::new();
 
@@ -180,6 +184,16 @@ fn fix(
         }
 
         let (mut errors, mut build_unit_map) = collect_errors(messages.into_iter(), &seen);
+        if build_unit_map.values().any(|file_map| !file_map.is_empty()) {
+            let primary_packages = if let Some(primary_packages) = &primary_packages_cache {
+                primary_packages
+            } else {
+                let metadata = package_metadata(&mut package_metadata_cache, &args.check_flags)?;
+                primary_packages_cache
+                    .insert(PrimaryPackages::from_metadata(metadata, &args.check_flags)?)
+            };
+            retain_primary_fixes(primary_packages, &mut errors, &mut build_unit_map);
+        }
 
         if iteration >= max_iterations {
             if active_targets.is_empty() {
@@ -261,12 +275,9 @@ fn fix(
                     }
 
                     if package_graph_cache.is_none() {
-                        package_graph_cache = Some(
-                            package_metadata(&mut package_metadata_cache, &args.check_flags)
-                                .and_then(|metadata| {
-                                    PackageGraph::load(metadata, &args.check_flags)
-                                }),
-                        );
+                        let metadata =
+                            package_metadata(&mut package_metadata_cache, &args.check_flags)?;
+                        package_graph_cache = Some(PackageGraph::load(metadata, &args.check_flags));
                     }
                     let Some(Some(graph)) = package_graph_cache.as_mut() else {
                         continue;
@@ -358,25 +369,150 @@ fn fix(
     Ok(())
 }
 
-/// Loads unresolved package metadata once, caching failed attempts.
+/// Packages that Cargo treats as primary for the current invocation.
+#[derive(Debug)]
+struct PrimaryPackages {
+    package_ids: HashSet<String>,
+}
+
+impl PrimaryPackages {
+    /// Reconstructs Cargo's primary package set from its package-selection flags.
+    fn from_metadata(metadata: &Metadata, flags: &CheckFlags) -> CargoResult<Self> {
+        let package_ids = match flags.package_selection() {
+            PackageSelection::Default => metadata
+                .workspace_default_members
+                .iter()
+                .map(|package_id| package_id.repr.clone())
+                .collect(),
+            PackageSelection::Workspace { exclude } => {
+                let matcher = PackageSpecMatcher::new(exclude)?;
+                let mut package_ids = HashSet::new();
+                for package in metadata.workspace_packages() {
+                    if !matcher.matches(package)? {
+                        package_ids.insert(package.id.repr.clone());
+                    }
+                }
+                package_ids
+            }
+            PackageSelection::Packages(packages) => {
+                let matcher = PackageSpecMatcher::new(packages)?;
+                let mut package_ids = HashSet::new();
+                for package in metadata.workspace_packages() {
+                    if matcher.matches(package)? {
+                        package_ids.insert(package.id.repr.clone());
+                    }
+                }
+                package_ids
+            }
+        };
+        Ok(Self { package_ids })
+    }
+
+    fn contains(&self, package_id: &str) -> bool {
+        self.package_ids.contains(package_id)
+    }
+}
+
+/// Matches Cargo package specifications and package-name glob patterns.
+#[derive(Debug)]
+struct PackageSpecMatcher {
+    specs: Vec<PackageIdSpec>,
+    patterns: Vec<glob::Pattern>,
+}
+
+impl PackageSpecMatcher {
+    fn new(raw_specs: &[String]) -> CargoResult<Self> {
+        let mut specs = Vec::new();
+        let mut patterns = Vec::new();
+
+        for raw_spec in raw_specs {
+            match PackageIdSpec::parse(raw_spec) {
+                Ok(spec) => specs.push(spec),
+                Err(_) if raw_spec.contains(&['*', '?', '[', ']'][..]) => {
+                    let pattern = glob::Pattern::new(raw_spec)
+                        .with_context(|| format!("failed to parse package pattern `{raw_spec}`"))?;
+                    patterns.push(pattern);
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to parse package specification `{raw_spec}`")
+                    });
+                }
+            }
+        }
+
+        Ok(Self { specs, patterns })
+    }
+
+    fn matches(&self, package: &cargo_metadata::Package) -> CargoResult<bool> {
+        if self
+            .patterns
+            .iter()
+            .any(|pattern| pattern.matches(package.name.as_ref()))
+        {
+            return Ok(true);
+        }
+
+        let package_id = PackageIdSpec::parse(&package.id.repr)
+            .with_context(|| format!("failed to parse package ID `{}`", package.id))?;
+        Ok(self
+            .specs
+            .iter()
+            .any(|spec| package_id_matches(spec, &package_id)))
+    }
+}
+
+/// Mirrors Cargo's internal package-ID matching rules.
+fn package_id_matches(spec: &PackageIdSpec, package_id: &PackageIdSpec) -> bool {
+    spec.name() == package_id.name()
+        && spec.partial_version().is_none_or(|version| {
+            package_id
+                .version()
+                .is_some_and(|package_version| version.matches(&package_version))
+        })
+        && spec.url().is_none_or(|url| package_id.url() == Some(url))
+        && spec
+            .kind()
+            .is_none_or(|kind| package_id.kind() == Some(kind))
+}
+
+/// Loads unresolved package metadata once and reuses it for selection and ordering.
 fn package_metadata<'a>(
-    cache: &'a mut Option<Option<Metadata>>,
+    cache: &'a mut Option<Metadata>,
     flags: &CheckFlags,
-) -> Option<&'a Metadata> {
-    cache
-        .get_or_insert_with(|| {
+) -> CargoResult<&'a Metadata> {
+    match cache {
+        Some(metadata) => Ok(metadata),
+        cache @ None => {
             let mut command = MetadataCommand::new();
             command.no_deps();
             command.other_options(flags.to_metadata_flags());
-            match command.exec() {
-                Ok(metadata) => Some(metadata),
-                Err(error) => {
-                    warn!("failed to run `cargo metadata`: {error}");
-                    None
-                }
-            }
-        })
-        .as_ref()
+            let metadata = command.exec().context("failed to run `cargo metadata`")?;
+            Ok(cache.insert(metadata))
+        }
+    }
+}
+
+/// Discards dependency suggestions while preserving their diagnostics for display.
+fn retain_primary_fixes(
+    primary_packages: &PrimaryPackages,
+    errors: &mut BuildUnitErrors,
+    build_unit_map: &mut BuildUnitSuggestions,
+) {
+    for (build_unit, file_map) in build_unit_map {
+        if file_map.is_empty() || primary_packages.contains(&build_unit.package_id) {
+            continue;
+        }
+
+        let build_unit_errors = errors.entry(build_unit.clone()).or_default();
+        build_unit_errors.extend(
+            file_map
+                .values()
+                .flatten()
+                .filter_map(|(_, diagnostic)| diagnostic.clone()),
+        );
+        file_map.clear();
+    }
 }
 
 /// Package dependencies used to batch only transitively unrelated packages.

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -62,6 +62,10 @@ struct File {
     original_source: String,
 }
 
+type BuildUnitErrors = IndexMap<BuildUnit, IndexSet<String>>;
+type BuildUnitSuggestions =
+    IndexMap<BuildUnit, IndexMap<String, IndexSet<(Suggestion, Option<String>)>>>;
+
 #[tracing::instrument(skip_all)]
 fn exec(args: FixitArgs) -> CargoResult<()> {
     args.color.write_global();
@@ -512,7 +516,7 @@ impl PackageGraph {
 fn finish_target(
     target: BuildUnit,
     active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
-    errors: &mut IndexMap<BuildUnit, IndexSet<String>>,
+    errors: &mut BuildUnitErrors,
     seen: &mut HashSet<BuildUnit>,
 ) -> CargoResult<()> {
     if seen
@@ -601,14 +605,10 @@ fn to_check_output(output: std::process::Output) -> (Vec<CheckOutput>, Option<i3
 }
 
 #[tracing::instrument(skip_all)]
-#[allow(clippy::type_complexity)]
 fn collect_errors(
     messages: impl Iterator<Item = CheckOutput>,
     seen: &HashSet<BuildUnit>,
-) -> (
-    IndexMap<BuildUnit, IndexSet<String>>,
-    IndexMap<BuildUnit, IndexMap<String, IndexSet<(Suggestion, Option<String>)>>>,
-) {
+) -> (BuildUnitErrors, BuildUnitSuggestions) {
     let only = HashSet::new();
     let mut build_unit_map = IndexMap::new();
 

--- a/src/util/cli.rs
+++ b/src/util/cli.rs
@@ -128,7 +128,29 @@ pub struct CheckFlags {
     frozen: bool,
 }
 
+/// Package selectors that determine which workspace packages Cargo treats as primary.
+#[derive(Debug)]
+pub(crate) enum PackageSelection<'a> {
+    Default,
+    Workspace { exclude: &'a [String] },
+    Packages(&'a [String]),
+}
+
 impl CheckFlags {
+    pub(crate) fn package_selection(&self) -> PackageSelection<'_> {
+        if self.workspace || self.all {
+            PackageSelection::Workspace {
+                exclude: &self.exclude,
+            }
+        } else if self.package.is_empty() {
+            debug_assert!(self.exclude.is_empty());
+            PackageSelection::Default
+        } else {
+            debug_assert!(self.exclude.is_empty());
+            PackageSelection::Packages(&self.package)
+        }
+    }
+
     pub fn to_flags(&self) -> Vec<String> {
         let mut out = Vec::new();
 

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -280,18 +280,13 @@ fn do_not_fix_non_relevant_deps() {
     p.cargo_("fix --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .cwd("foo")
-        .with_stderr_data(str![[r#"
-[CHECKING] bar v0.1.0
-[FIXED] [ROOT]/foo/bar/src/lib.rs (1 fix)
-
-"#]])
         .run();
 
-    assert!(!p.read_file("bar/src/lib.rs").contains("mut"));
+    assert!(p.read_file("bar/src/lib.rs").contains("mut"));
 }
 
 #[cargo_test]
-fn fixes_dependency_of_default_workspace_member() {
+fn does_not_fix_dependency_of_default_workspace_member() {
     let p = package_selection_project(
         "[workspace]\nmembers = ['a', 'b']\ndefault-members = ['a']\nresolver = '2'\n",
     );
@@ -299,28 +294,28 @@ fn fixes_dependency_of_default_workspace_member() {
     p.cargo_("fix --allow-no-vcs").run();
 
     assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
-    assert!(!p.read_file("b/src/lib.rs").contains("let mut value"));
+    assert!(p.read_file("b/src/lib.rs").contains("let mut value"));
 }
 
 #[cargo_test]
-fn fixes_dependency_of_selected_workspace_package() {
+fn does_not_fix_dependency_of_selected_workspace_package() {
     let p = package_selection_project("[workspace]\nmembers = ['a', 'b']\nresolver = '2'\n");
 
     p.cargo_("fix --package a --allow-no-vcs").run();
 
     assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
-    assert!(!p.read_file("b/src/lib.rs").contains("let mut value"));
+    assert!(p.read_file("b/src/lib.rs").contains("let mut value"));
 }
 
 #[cargo_test]
-fn fixes_excluded_workspace_dependency() {
+fn does_not_fix_excluded_workspace_dependency() {
     let p = package_selection_project("[workspace]\nmembers = ['a', 'b']\nresolver = '2'\n");
 
     p.cargo_("fix --workspace --exclude b* --allow-no-vcs")
         .run();
 
     assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
-    assert!(!p.read_file("b/src/lib.rs").contains("let mut value"));
+    assert!(p.read_file("b/src/lib.rs").contains("let mut value"));
 }
 
 fn package_selection_project(workspace_manifest: &str) -> Project {
@@ -351,7 +346,7 @@ fn package_selection_project(workspace_manifest: &str) -> Project {
 }
 
 #[cargo_test]
-fn clippy_fixes_denied_warnings_in_external_path_dependencies() {
+fn clippy_does_not_fix_non_relevant_path_dependencies() {
     let p = project()
         .no_manifest()
         .file(
@@ -378,7 +373,7 @@ fn clippy_fixes_denied_warnings_in_external_path_dependencies() {
 
     p.cargo_("fix --clippy --allow-no-vcs").cwd("foo").run();
 
-    assert!(!p.read_file("bar/src/lib.rs").contains("let mut value"));
+    assert!(p.read_file("bar/src/lib.rs").contains("let mut value"));
 }
 
 #[cargo_test]

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -291,6 +291,66 @@ fn do_not_fix_non_relevant_deps() {
 }
 
 #[cargo_test]
+fn fixes_dependency_of_default_workspace_member() {
+    let p = package_selection_project(
+        "[workspace]\nmembers = ['a', 'b']\ndefault-members = ['a']\nresolver = '2'\n",
+    );
+
+    p.cargo_("fix --allow-no-vcs").run();
+
+    assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
+    assert!(!p.read_file("b/src/lib.rs").contains("let mut value"));
+}
+
+#[cargo_test]
+fn fixes_dependency_of_selected_workspace_package() {
+    let p = package_selection_project("[workspace]\nmembers = ['a', 'b']\nresolver = '2'\n");
+
+    p.cargo_("fix --package a --allow-no-vcs").run();
+
+    assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
+    assert!(!p.read_file("b/src/lib.rs").contains("let mut value"));
+}
+
+#[cargo_test]
+fn fixes_excluded_workspace_dependency() {
+    let p = package_selection_project("[workspace]\nmembers = ['a', 'b']\nresolver = '2'\n");
+
+    p.cargo_("fix --workspace --exclude b* --allow-no-vcs")
+        .run();
+
+    assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
+    assert!(!p.read_file("b/src/lib.rs").contains("let mut value"));
+}
+
+fn package_selection_project(workspace_manifest: &str) -> Project {
+    project()
+        .file("Cargo.toml", workspace_manifest)
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                b = { path = '../b' }
+            "#,
+        )
+        .file(
+            "a/src/lib.rs",
+            "pub fn value() -> usize { let mut value = b::value(); value }\n",
+        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
+        .file(
+            "b/src/lib.rs",
+            "pub fn value() -> usize { let mut value = 1; value }\n",
+        )
+        .build()
+}
+
+#[cargo_test]
 fn clippy_fixes_denied_warnings_in_external_path_dependencies() {
     let p = project()
         .no_manifest()

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -75,7 +75,7 @@ json-diagnostic-rendered-ansi
 }
 
 #[cargo_test]
-fn single_package_skips_dependency_metadata() {
+fn single_package_loads_primary_package_metadata() {
     let fake_cargo = fake_cargo();
 
     let p = project()
@@ -88,6 +88,7 @@ fn single_package_skips_dependency_metadata() {
             "fn main() { let mut value = 1; let _ = value; }\n",
         )
         .build();
+    let metadata_log = p.root().join("metadata.log");
 
     let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
     command.cwd(p.root());
@@ -95,6 +96,7 @@ fn single_package_skips_dependency_metadata() {
     command.arg("--allow-no-vcs");
     command.env("CARGO", fake_cargo.bin("fake-cargo"));
     command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+    command.env("FIXIT_METADATA_LOG", &metadata_log);
     command.env("FIXIT_LOG", "cargo_fixit=warn");
 
     cargo_test_support::execs()
@@ -109,6 +111,15 @@ fn single_package_skips_dependency_metadata() {
 
     assert!(!p.read_file("src/lib.rs").contains("let mut value"));
     assert!(!p.read_file("src/main.rs").contains("let mut value"));
+    assert_ui().eq(
+        p.read_file("metadata.log"),
+        str![[r#"
+metadata
+--format-version
+1
+--no-deps
+"#]],
+    );
 }
 
 fn fake_cargo() -> Project {
@@ -121,7 +132,14 @@ fn fake_cargo() -> Project {
             fn main() {
                 let args = std::env::args_os().skip(1).collect::<Vec<_>>();
                 if args.first().is_some_and(|arg| arg == "metadata") {
-                    std::process::exit(1);
+                    if let Some(log) = std::env::var_os("FIXIT_METADATA_LOG") {
+                        let args = args
+                            .iter()
+                            .map(|arg| arg.to_string_lossy())
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        std::fs::write(log, args).unwrap();
+                    }
                 }
 
                 if let Some(marker) = std::env::var_os("CARGO_FIXIT_FAKE_CARGO_MARKER") {
@@ -674,7 +692,7 @@ metadata --format-version 1 --no-deps
 
 #[cfg(unix)]
 #[cargo_test(nightly, reason = "-Zscript is unstable")]
-fn cargo_script_falls_back_to_resolved_metadata() {
+fn cargo_script_selects_only_script_package() {
     use std::os::unix::fs::PermissionsExt;
 
     let p = project()
@@ -737,10 +755,9 @@ exec "$FIXIT_REAL_CARGO" "$@"
         p.read_file("metadata.log").trim_end(),
         str![[r#"
 metadata --format-version 1 --no-deps -Z script --manifest-path script.rs
-metadata --format-version 1 -Z script --manifest-path script.rs
 "#]],
     );
-    assert!(!p.read_file("src/lib.rs").contains("let mut value"));
+    assert!(p.read_file("src/lib.rs").contains("let mut value"));
     assert!(!p.read_file("script.rs").contains("let mut value"));
 }
 


### PR DESCRIPTION
## Summary

Cargo compiles selected packages together with their dependencies, but its compiler messages do not identify which packages are primary. We currently apply every machine-applicable suggestion in that output, so selecting one package can modify an unselected path dependency.

This PR loads `cargo metadata --no-deps` after the first fixable suggestion and reconstructs the primary package set for default workspace members, explicit package specs and globs, and workspace exclusions. Suggestions from non-primary packages are ignored while their diagnostics remain visible. The metadata result is cached and shared with dependency batching; clean runs without suggestions still avoid metadata.

Closes https://github.com/crate-ci/cargo-fixit/issues/70.
