### PR TITLE
perf: Pipeline independent fix batches

### DIFF
--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -111,6 +111,7 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
+    let mut target_iterations: HashMap<BuildUnit, usize> = HashMap::new();
     let mut package_metadata_cache = None;
     let mut primary_packages_cache = None;
     let mut package_graph_cache: Option<Option<PackageGraph>> = None;
@@ -210,10 +211,13 @@ fn fix(
             retain_primary_fixes(primary_packages, &mut errors, &mut build_unit_map);
         }
 
-        if iteration >= max_iterations {
-            if active_targets.is_empty() {
-                break;
-            }
+        if max_iterations == 0 {
+            break;
+        }
+
+        if active_targets.keys().any(|target| {
+            target_iterations.get(target).copied().unwrap_or_default() >= max_iterations
+        }) {
             let targets: Vec<_> = active_targets.keys().cloned().collect();
             for target in targets {
                 if let Some(file_map) = build_unit_map.get(&target) {
@@ -228,6 +232,7 @@ fn fix(
                 finish_target(target, active_targets, &mut errors, &mut seen)?;
             }
             claimed_files.clear();
+            target_iterations.clear();
             iteration = 0;
         }
 
@@ -244,6 +249,7 @@ fn fix(
             }
             debug_assert!(active_targets.is_empty());
             claimed_files.clear();
+            target_iterations.clear();
             iteration = 0;
             finalized_targets = true;
         }
@@ -337,6 +343,7 @@ fn fix(
                     active_targets.shift_remove(&build_unit);
                 }
                 if changed {
+                    *target_iterations.entry(build_unit.clone()).or_default() += 1;
                     if let Some(handles) = handles {
                         for handle in handles {
                             claimed_files.entry(handle).or_insert(build_unit.clone());
@@ -365,6 +372,7 @@ fn fix(
                 finish_target(target, active_targets, &mut last_errors, &mut seen)?;
             }
             claimed_files.clear();
+            target_iterations.clear();
             iteration = 0;
             continue;
         }

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -87,10 +87,13 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     match fix(&args, &mut active_targets) {
         Ok(()) => Ok(()),
         Err(error) => {
+            let mut restoration_error = None;
             for (file, original) in active_targets.values().flat_map(|files| files.iter()) {
-                paths::write(file, &original.original_source)?;
+                if let Err(error) = paths::write(file, &original.original_source) {
+                    restoration_error.get_or_insert(error);
+                }
             }
-            Err(error)
+            Err(restoration_error.unwrap_or(error))
         }
     }
 }

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -84,11 +84,18 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     args.vcs_opts.valid_vcs()?;
 
     let mut active_targets = IndexMap::new();
-    match fix(&args, &mut active_targets) {
+    // Keep completed targets recoverable while their original batch is still active.
+    let mut retired_targets = IndexMap::new();
+    match fix(&args, &mut active_targets, &mut retired_targets) {
         Ok(()) => Ok(()),
         Err(error) => {
             let mut restoration_error = None;
-            for (file, original) in active_targets.values().flat_map(|files| files.iter()) {
+            for (file, original) in active_targets
+                .values()
+                .rev()
+                .chain(retired_targets.values().rev())
+                .flat_map(|files| files.iter().rev())
+            {
                 if let Err(error) = paths::write(file, &original.original_source) {
                     restoration_error.get_or_insert(error);
                 }
@@ -101,6 +108,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 fn fix(
     args: &FixitArgs,
     active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+    retired_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
 ) -> CargoResult<()> {
     let max_iterations: usize = env::var("CARGO_FIX_MAX_RETRIES")
         .ok()
@@ -129,7 +137,7 @@ fn fix(
         } else if !args.broken_code && exit_code != Some(0) {
             let mut out = String::new();
 
-            if !active_targets.is_empty() {
+            if !active_targets.is_empty() || !retired_targets.is_empty() {
                 out.push_str(
                     "failed to automatically apply fixes suggested by rustc\n\n\
                     after fixes were automatically applied the \
@@ -142,13 +150,18 @@ fn fix(
                         fixes: _,
                         original_source,
                     },
-                ) in active_targets.values().flat_map(|files| files.iter())
+                ) in active_targets
+                    .values()
+                    .rev()
+                    .chain(retired_targets.values().rev())
+                    .flat_map(|files| files.iter().rev())
                 {
                     out.push_str(&format!("  * {file}\n"));
                     shell::note(format!("reverting `{file}` to its original state"))?;
                     paths::write(file, original_source)?;
                 }
                 active_targets.clear();
+                retired_targets.clear();
                 out.push('\n');
 
                 out.push_str(&gen_please_report_this_bug_text(args.clippy));
@@ -215,11 +228,18 @@ fn fix(
             break;
         }
 
-        if active_targets.keys().any(|target| {
-            target_iterations.get(target).copied().unwrap_or_default() >= max_iterations
-        }) {
-            let targets: Vec<_> = active_targets.keys().cloned().collect();
-            for target in targets {
+        let mut finalized_targets = false;
+        // Retire targets separately so their dependents can join the next wave.
+        let targets: Vec<_> = active_targets
+            .keys()
+            .filter(|target| {
+                target_iterations.get(*target).copied().unwrap_or_default() >= max_iterations
+                    || build_unit_map.get(*target).is_none_or(IndexMap::is_empty)
+            })
+            .cloned()
+            .collect();
+        for target in targets {
+            if target_iterations.get(&target).copied().unwrap_or_default() >= max_iterations {
                 if let Some(file_map) = build_unit_map.get(&target) {
                     let target_errors = errors.entry(target.clone()).or_default();
                     target_errors.extend(
@@ -229,35 +249,27 @@ fn fix(
                             .filter_map(|(_, diagnostic)| diagnostic.clone()),
                     );
                 }
-                finish_target(target, active_targets, &mut errors, &mut seen)?;
+            } else {
+                build_unit_map.shift_remove(&target);
             }
-            claimed_files.clear();
-            target_iterations.clear();
-            iteration = 0;
+            finish_target(
+                target.clone(),
+                active_targets,
+                retired_targets,
+                &mut errors,
+                &mut seen,
+            )?;
+            claimed_files.retain(|_, owner| owner != &target);
+            target_iterations.remove(&target);
+            finalized_targets = true;
         }
 
-        let mut finalized_targets = false;
-        if !active_targets.is_empty()
-            && active_targets
-                .keys()
-                .all(|target| build_unit_map.get(target).is_none_or(IndexMap::is_empty))
-        {
-            let targets: Vec<_> = active_targets.keys().cloned().collect();
-            for target in targets {
-                build_unit_map.shift_remove(&target);
-                finish_target(target, active_targets, &mut errors, &mut seen)?;
-            }
-            debug_assert!(active_targets.is_empty());
-            claimed_files.clear();
-            target_iterations.clear();
-            iteration = 0;
-            finalized_targets = true;
+        if active_targets.is_empty() {
+            retired_targets.clear();
         }
 
         let mut made_changes = false;
         // Admit build units from one compiler snapshot only when their packages are independent.
-        // Once a batch is active, recheck and finish it before considering additional units.
-        let continuing_batch = !active_targets.is_empty();
 
         for (build_unit, file_map) in build_unit_map {
             if seen.contains(&build_unit) {
@@ -283,9 +295,6 @@ fn fix(
                 seen.insert(build_unit);
             } else if !file_map.is_empty() {
                 let was_active = active_targets.contains_key(&build_unit);
-                if continuing_batch && !was_active {
-                    continue;
-                }
 
                 if !args.dangerous_parallel_fixes && !was_active && !active_targets.is_empty() {
                     if active_targets
@@ -369,11 +378,17 @@ fn fix(
             }
             let targets: Vec<_> = active_targets.keys().cloned().collect();
             for target in targets {
-                finish_target(target, active_targets, &mut last_errors, &mut seen)?;
+                finish_target(
+                    target,
+                    active_targets,
+                    retired_targets,
+                    &mut last_errors,
+                    &mut seen,
+                )?;
             }
             claimed_files.clear();
             target_iterations.clear();
-            iteration = 0;
+            retired_targets.clear();
             continue;
         }
     }
@@ -389,6 +404,7 @@ fn fix(
     }
 
     active_targets.clear();
+    retired_targets.clear();
     Ok(())
 }
 
@@ -675,6 +691,7 @@ impl PackageGraph {
 fn finish_target(
     target: BuildUnit,
     active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+    retired_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
     errors: &mut BuildUnitErrors,
     seen: &mut HashSet<BuildUnit>,
 ) -> CargoResult<()> {
@@ -695,7 +712,9 @@ fn finish_target(
         shell::print_ansi_stderr(format!("{}\n\n", error.trim_end()).as_bytes())?;
     }
 
-    active_targets.shift_remove(&target);
+    if let Some(files) = active_targets.shift_remove(&target) {
+        retired_targets.insert(target.clone(), files);
+    }
     errors.shift_remove(&target);
     seen.insert(target);
     Ok(())

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -554,7 +554,7 @@ fn independent_packages_progress_while_another_retries() {
     ] {
         assert!(!p.read_file(path).contains("let mut"));
     }
-    assert_eq!(p.read_file("check.log").lines().count(), 4);
+    assert_eq!(p.read_file("check.log").lines().count(), 3);
     assert_eq!(
         crate::fix::rustc_invocations(&rustc_log, ["dependency", "consumer", "slow"]),
         [2, 3, 3]

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -124,13 +124,25 @@ metadata
 
 fn fake_cargo() -> Project {
     let fake_cargo = project()
-        .at(cargo_test_support::paths::global_root().join("fake-cargo"))
+        .at("fake-cargo")
         .file("Cargo.toml", &basic_manifest("fake-cargo", "1.0.0"))
         .file(
             "src/main.rs",
             r#"
             fn main() {
                 let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+                if args.first().is_some_and(|arg| arg == "check") {
+                    if let Some(log) = std::env::var_os("FIXIT_CHECK_LOG") {
+                        use std::io::Write as _;
+
+                        let mut log = std::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(log)
+                            .unwrap();
+                        writeln!(log, "check").unwrap();
+                    }
+                }
                 if args.first().is_some_and(|arg| arg == "metadata") {
                     if let Some(log) = std::env::var_os("FIXIT_METADATA_LOG") {
                         let args = args
@@ -511,6 +523,158 @@ fn independent_workspace_packages() {
             format!("pub fn {name}() {{ let value = 1; let _ = value; }}\n")
         );
     }
+}
+
+#[cargo_test]
+fn independent_packages_progress_while_another_retries() {
+    let fake_cargo = fake_cargo();
+    let p = rolling_wavefront_project();
+    let check_log = p.root().join("check.log");
+    let rustc_log = p.root().join("rustc.log");
+    std::fs::create_dir_all(&rustc_log).unwrap();
+
+    let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+    command.cwd(p.root());
+    command.arg("fixit");
+    command.arg("--workspace");
+    command.arg("--allow-no-vcs");
+    command.env("CARGO", fake_cargo.bin("fake-cargo"));
+    command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+    command.env("FIXIT_CHECK_LOG", &check_log);
+    command.env("RUSTC_WORKSPACE_WRAPPER", crate::fix::echo_wrapper());
+    command.env("__CARGO_FIXIT_RUSTC_LOG", &rustc_log);
+    cargo_test_support::execs()
+        .with_process_builder(command)
+        .run();
+
+    for path in [
+        "dependency/src/lib.rs",
+        "consumer/src/lib.rs",
+        "slow/src/lib.rs",
+    ] {
+        assert!(!p.read_file(path).contains("let mut"));
+    }
+    assert_eq!(p.read_file("check.log").lines().count(), 4);
+    assert_eq!(
+        crate::fix::rustc_invocations(&rustc_log, ["dependency", "consumer", "slow"]),
+        [2, 3, 3]
+    );
+}
+
+#[cargo_test]
+fn rolling_wavefront_restores_retired_packages_on_failure() {
+    let p = rolling_wavefront_project();
+    let original_dependency = p.read_file("dependency/src/lib.rs");
+    let original_consumer = p.read_file("consumer/src/lib.rs");
+    let original_slow = p.read_file("slow/src/lib.rs");
+
+    p.cargo_("fixit --workspace --allow-no-vcs")
+        .env("FIXIT_BREAK_AFTER_FIXES", "1")
+        .with_status(101)
+        .with_stderr_contains("[NOTE] reverting `dependency/src/lib.rs` to its original state")
+        .run();
+
+    assert_eq!(p.read_file("dependency/src/lib.rs"), original_dependency);
+    assert_eq!(p.read_file("consumer/src/lib.rs"), original_consumer);
+    assert_eq!(p.read_file("slow/src/lib.rs"), original_slow);
+}
+
+#[cargo_test]
+fn rolling_wavefront_restores_shared_files_in_reverse_order() {
+    let p = rolling_wavefront_project();
+    p.change_file(
+        "dependency/Cargo.toml",
+        &format!(
+            "{}\n[features]\ndefault = ['first']\nfirst = []\nsecond = []\n",
+            basic_manifest("dependency", "0.1.0")
+        ),
+    );
+    p.change_file(
+        "dependency/src/lib.rs",
+        "#[cfg(feature = \"first\")]\npub fn dependency() -> usize { let mut first = 1; first }\n\n#[cfg(feature = \"second\")]\npub fn shared() -> usize { let mut second = 1; second }\n",
+    );
+    p.change_file(
+        "consumer/Cargo.toml",
+        &format!(
+            "{}\n[features]\ndefault = ['second']\nfirst = []\nsecond = []\n\n[dependencies]\ndependency = {{ path = '../dependency' }}\n",
+            basic_manifest("consumer", "0.1.0")
+        ),
+    );
+    p.change_file(
+        "consumer/src/lib.rs",
+        "#[path = \"../../dependency/src/lib.rs\"]\nmod shared;\npub fn consumer() -> usize { dependency::dependency() + shared::shared() }\n",
+    );
+    let original_shared = p.read_file("dependency/src/lib.rs");
+
+    p.cargo_("fixit --workspace --allow-no-vcs")
+        .env("FIXIT_BREAK_AFTER_FIXES", "1")
+        .with_status(101)
+        .with_stderr_contains("[NOTE] reverting `dependency/src/lib.rs` to its original state")
+        .run();
+
+    assert_eq!(p.read_file("dependency/src/lib.rs"), original_shared);
+}
+
+fn rolling_wavefront_project() -> Project {
+    project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = ['dependency', 'consumer', 'slow']\nresolver = '2'\n",
+        )
+        .file("dependency/Cargo.toml", &basic_manifest("dependency", "0.1.0"))
+        .file(
+            "dependency/src/lib.rs",
+            "pub fn dependency() -> usize { let mut value = 1; value }\n",
+        )
+        .file(
+            "consumer/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\ndependency = {{ path = '../dependency' }}\n",
+                basic_manifest("consumer", "0.1.0")
+            ),
+        )
+        .file(
+            "consumer/src/lib.rs",
+            "pub fn consumer() -> usize { let mut value = dependency::dependency(); value }\n",
+        )
+        .file("slow/Cargo.toml", &basic_manifest("slow", "0.1.0"))
+        .file(
+            "slow/build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-check-cfg=cfg(fixit_first)");
+                    println!("cargo:rustc-check-cfg=cfg(fixit_second)");
+                    println!("cargo:rustc-check-cfg=cfg(fixit_broken)");
+                    println!("cargo:rerun-if-changed=src/lib.rs");
+
+                    let source = std::fs::read_to_string("src/lib.rs").unwrap();
+                    if source.contains("let mut first") {
+                        println!("cargo:rustc-cfg=fixit_first");
+                    } else if source.contains("let mut second") {
+                        println!("cargo:rustc-cfg=fixit_second");
+                    } else if std::env::var_os("FIXIT_BREAK_AFTER_FIXES").is_some() {
+                        println!("cargo:rustc-cfg=fixit_broken");
+                    }
+                }
+            "#,
+        )
+        .file(
+            "slow/src/lib.rs",
+            r#"
+                #[cfg(fixit_first)]
+                pub fn slow() -> usize { let mut first = 1; first }
+
+                #[cfg(fixit_second)]
+                pub fn slow() -> usize { let mut second = 1; second }
+
+                #[cfg(not(any(fixit_first, fixit_second)))]
+                pub fn slow() -> usize { 1 }
+
+                #[cfg(fixit_broken)]
+                pub fn broken() -> usize { missing_value() }
+            "#,
+        )
+        .build()
 }
 
 #[cargo_test]


### PR DESCRIPTION
## Summary

Cargo currently waits for every target in a fix batch to finish before admitting another target. Retire finished package targets individually so their dependents can start while unrelated targets continue applying fixes.

The commits first capture the existing four-pass behavior, then isolate source-restoration error handling, refactor retry tracking per target without changing scheduling, and finally enable pipelining. A zero retry budget continues to collect diagnostics without applying fixes.

Package dependency ordering, physical-file conflict checks, and transactional source restoration are preserved.

## Benchmarks

Synthetic workspaces containing a dependency chain and an unrelated package that needs several fix rounds:

| Workload | Main median | This PR median | Cargo checks | rustc calls | Improvement |
| --- | ---: | ---: | ---: | ---: | ---: |
| 2-package chain + 2-round peer | 754.3 ms | 649.7 ms | 4 → 3 | 8 → 8 | 13.9% |
| 6-package chain + 6-round peer | 2,798.7 ms | 1,885.6 ms | 12 → 7 | 34 → 34 | 32.6% |

Release builds; seven timed runs after warmup on macOS 26.6 arm64 with Rust 1.96.0. Fixture sources were restored before every run, the incremental Cargo cache remained warm, and variant order rotated between rounds. The compiler performs the same work; the improvement comes from avoiding repeated Cargo invocations.
