### PR TITLE
feat: Opt in to parallel executable-target fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Expectations
 - Edition migration is unsupported
 - The CLI is modeled off of `cargo fix` 1.89 (no implicit `--all-targets`)
 
+## Opt-in target parallelism
+
+Executable targets with independent sources and build inputs can be fixed in the same pass:
+
+```console
+$ cargo fixit --Zassume-independent-targets
+```
+
+This optimization is disabled by default. `include!`, `#[path]`, build scripts,
+and procedural macros can make targets depend on each other's sources. Successful
+compilation cannot prove semantic equivalence, so only opt in when those inputs
+are independent.
+
 ## License
 
 Licensed under either of

--- a/src/ops/check.rs
+++ b/src/ops/check.rs
@@ -45,6 +45,16 @@ pub struct BuildUnit {
     pub target: Target,
 }
 
+impl BuildUnit {
+    /// Returns whether this is a binary-shaped bin, example, test, or benchmark target.
+    pub(crate) fn is_executable_leaf(&self) -> bool {
+        matches!(
+            self.target.kind.as_slice(),
+            [Kind::Bin | Kind::Example | Kind::Test | Kind::Bench]
+        ) && matches!(self.target.crate_types.as_slice(), [CrateType::Bin])
+    }
+}
+
 #[derive(Deserialize, Hash, PartialEq, Clone, Eq, Debug)]
 pub struct Target {
     kind: Vec<Kind>,

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -111,6 +111,7 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
+    let mut target_iterations: HashMap<BuildUnit, usize> = HashMap::new();
     let mut package_metadata_cache = None;
     let mut primary_packages_cache = None;
     let mut package_graph_cache: Option<Option<PackageGraph>> = None;
@@ -210,10 +211,13 @@ fn fix(
             retain_primary_fixes(primary_packages, &mut errors, &mut build_unit_map);
         }
 
-        if iteration >= max_iterations {
-            if active_targets.is_empty() {
-                break;
-            }
+        if max_iterations == 0 {
+            break;
+        }
+
+        if active_targets.keys().any(|target| {
+            target_iterations.get(target).copied().unwrap_or_default() >= max_iterations
+        }) {
             let targets: Vec<_> = active_targets.keys().cloned().collect();
             for target in targets {
                 if let Some(file_map) = build_unit_map.get(&target) {
@@ -228,6 +232,7 @@ fn fix(
                 finish_target(target, active_targets, &mut errors, &mut seen)?;
             }
             claimed_files.clear();
+            target_iterations.clear();
             iteration = 0;
         }
 
@@ -244,6 +249,7 @@ fn fix(
             }
             debug_assert!(active_targets.is_empty());
             claimed_files.clear();
+            target_iterations.clear();
             iteration = 0;
             finalized_targets = true;
         }
@@ -337,6 +343,7 @@ fn fix(
                     active_targets.shift_remove(&build_unit);
                 }
                 if changed {
+                    *target_iterations.entry(build_unit.clone()).or_default() += 1;
                     if let Some(handles) = handles {
                         for handle in handles {
                             claimed_files.entry(handle).or_insert(build_unit.clone());
@@ -365,6 +372,7 @@ fn fix(
                 finish_target(target, active_targets, &mut last_errors, &mut seen)?;
             }
             claimed_files.clear();
+            target_iterations.clear();
             iteration = 0;
             continue;
         }

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -87,10 +87,13 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     match fix(&args, &mut active_targets) {
         Ok(()) => Ok(()),
         Err(error) => {
+            let mut restoration_error = None;
             for (file, original) in active_targets.values().flat_map(|files| files.iter()) {
-                paths::write(file, &original.original_source)?;
+                if let Err(error) = paths::write(file, &original.original_source) {
+                    restoration_error.get_or_insert(error);
+                }
             }
-            Err(error)
+            Err(restoration_error.unwrap_or(error))
         }
     }
 }

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -84,11 +84,18 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     args.vcs_opts.valid_vcs()?;
 
     let mut active_targets = IndexMap::new();
-    match fix(&args, &mut active_targets) {
+    // Keep completed targets recoverable while their original batch is still active.
+    let mut retired_targets = IndexMap::new();
+    match fix(&args, &mut active_targets, &mut retired_targets) {
         Ok(()) => Ok(()),
         Err(error) => {
             let mut restoration_error = None;
-            for (file, original) in active_targets.values().flat_map(|files| files.iter()) {
+            for (file, original) in active_targets
+                .values()
+                .rev()
+                .chain(retired_targets.values().rev())
+                .flat_map(|files| files.iter().rev())
+            {
                 if let Err(error) = paths::write(file, &original.original_source) {
                     restoration_error.get_or_insert(error);
                 }
@@ -101,6 +108,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 fn fix(
     args: &FixitArgs,
     active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+    retired_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
 ) -> CargoResult<()> {
     let max_iterations: usize = env::var("CARGO_FIX_MAX_RETRIES")
         .ok()
@@ -129,7 +137,7 @@ fn fix(
         } else if !args.broken_code && exit_code != Some(0) {
             let mut out = String::new();
 
-            if !active_targets.is_empty() {
+            if !active_targets.is_empty() || !retired_targets.is_empty() {
                 out.push_str(
                     "failed to automatically apply fixes suggested by rustc\n\n\
                     after fixes were automatically applied the \
@@ -142,13 +150,18 @@ fn fix(
                         fixes: _,
                         original_source,
                     },
-                ) in active_targets.values().flat_map(|files| files.iter())
+                ) in active_targets
+                    .values()
+                    .rev()
+                    .chain(retired_targets.values().rev())
+                    .flat_map(|files| files.iter().rev())
                 {
                     out.push_str(&format!("  * {file}\n"));
                     shell::note(format!("reverting `{file}` to its original state"))?;
                     paths::write(file, original_source)?;
                 }
                 active_targets.clear();
+                retired_targets.clear();
                 out.push('\n');
 
                 out.push_str(&gen_please_report_this_bug_text(args.clippy));
@@ -215,11 +228,18 @@ fn fix(
             break;
         }
 
-        if active_targets.keys().any(|target| {
-            target_iterations.get(target).copied().unwrap_or_default() >= max_iterations
-        }) {
-            let targets: Vec<_> = active_targets.keys().cloned().collect();
-            for target in targets {
+        let mut finalized_targets = false;
+        // Retire targets separately so their dependents can join the next wave.
+        let targets: Vec<_> = active_targets
+            .keys()
+            .filter(|target| {
+                target_iterations.get(*target).copied().unwrap_or_default() >= max_iterations
+                    || build_unit_map.get(*target).is_none_or(IndexMap::is_empty)
+            })
+            .cloned()
+            .collect();
+        for target in targets {
+            if target_iterations.get(&target).copied().unwrap_or_default() >= max_iterations {
                 if let Some(file_map) = build_unit_map.get(&target) {
                     let target_errors = errors.entry(target.clone()).or_default();
                     target_errors.extend(
@@ -229,35 +249,27 @@ fn fix(
                             .filter_map(|(_, diagnostic)| diagnostic.clone()),
                     );
                 }
-                finish_target(target, active_targets, &mut errors, &mut seen)?;
+            } else {
+                build_unit_map.shift_remove(&target);
             }
-            claimed_files.clear();
-            target_iterations.clear();
-            iteration = 0;
+            finish_target(
+                target.clone(),
+                active_targets,
+                retired_targets,
+                &mut errors,
+                &mut seen,
+            )?;
+            claimed_files.retain(|_, owner| owner != &target);
+            target_iterations.remove(&target);
+            finalized_targets = true;
         }
 
-        let mut finalized_targets = false;
-        if !active_targets.is_empty()
-            && active_targets
-                .keys()
-                .all(|target| build_unit_map.get(target).is_none_or(IndexMap::is_empty))
-        {
-            let targets: Vec<_> = active_targets.keys().cloned().collect();
-            for target in targets {
-                build_unit_map.shift_remove(&target);
-                finish_target(target, active_targets, &mut errors, &mut seen)?;
-            }
-            debug_assert!(active_targets.is_empty());
-            claimed_files.clear();
-            target_iterations.clear();
-            iteration = 0;
-            finalized_targets = true;
+        if active_targets.is_empty() {
+            retired_targets.clear();
         }
 
         let mut made_changes = false;
         // Admit build units from one compiler snapshot only when their packages are independent.
-        // Once a batch is active, recheck and finish it before considering additional units.
-        let continuing_batch = !active_targets.is_empty();
 
         for (build_unit, file_map) in build_unit_map {
             if seen.contains(&build_unit) {
@@ -283,9 +295,6 @@ fn fix(
                 seen.insert(build_unit);
             } else if !file_map.is_empty() {
                 let was_active = active_targets.contains_key(&build_unit);
-                if continuing_batch && !was_active {
-                    continue;
-                }
 
                 if !args.dangerous_parallel_fixes && !was_active && !active_targets.is_empty() {
                     if active_targets
@@ -369,11 +378,17 @@ fn fix(
             }
             let targets: Vec<_> = active_targets.keys().cloned().collect();
             for target in targets {
-                finish_target(target, active_targets, &mut last_errors, &mut seen)?;
+                finish_target(
+                    target,
+                    active_targets,
+                    retired_targets,
+                    &mut last_errors,
+                    &mut seen,
+                )?;
             }
             claimed_files.clear();
             target_iterations.clear();
-            iteration = 0;
+            retired_targets.clear();
             continue;
         }
     }
@@ -389,6 +404,7 @@ fn fix(
     }
 
     active_targets.clear();
+    retired_targets.clear();
     Ok(())
 }
 
@@ -675,6 +691,7 @@ impl PackageGraph {
 fn finish_target(
     target: BuildUnit,
     active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+    retired_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
     errors: &mut BuildUnitErrors,
     seen: &mut HashSet<BuildUnit>,
 ) -> CargoResult<()> {
@@ -695,7 +712,9 @@ fn finish_target(
         shell::print_ansi_stderr(format!("{}\n\n", error.trim_end()).as_bytes())?;
     }
 
-    active_targets.shift_remove(&target);
+    if let Some(files) = active_targets.shift_remove(&target) {
+        retired_targets.insert(target.clone(), files);
+    }
     errors.shift_remove(&target);
     seen.insert(target);
     Ok(())

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -39,6 +39,10 @@ pub struct FixitArgs {
     #[arg(long)]
     broken_code: bool,
 
+    /// Assume executable targets are independent (stale fixes may change behavior)
+    #[arg(long = "Zassume-independent-targets")]
+    assume_independent_targets: bool,
+
     /// Fix all targets together, risking stale suggestions
     #[arg(long = "Zdangerous-parallel-fixes")]
     dangerous_parallel_fixes: bool,
@@ -116,6 +120,9 @@ fn fix(
         .unwrap_or(4);
     let mut iteration = 0;
     let mut lint_cap = false;
+    let mut parallel_leaf_targets =
+        args.assume_independent_targets && !args.broken_code && !args.dangerous_parallel_fixes;
+    let mut speculative_leaf_batch = false;
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
@@ -128,7 +135,28 @@ fn fix(
     loop {
         trace!("iteration={iteration}");
         trace!("active_targets={active_targets:?}");
+        let previous_lint_cap = lint_cap;
         let (messages, exit_code) = check(args, &mut lint_cap)?;
+
+        // Executable targets can still read one another's sources indirectly.
+        if exit_code != Some(0) && speculative_leaf_batch {
+            for (file, original) in active_targets
+                .values()
+                .rev()
+                .flat_map(|files| files.iter().rev())
+            {
+                paths::write(file, &original.original_source)?;
+            }
+            active_targets.clear();
+            claimed_files.clear();
+            target_iterations.clear();
+            last_errors.clear();
+            iteration = 0;
+            lint_cap = previous_lint_cap;
+            parallel_leaf_targets = false;
+            speculative_leaf_batch = false;
+            continue;
+        }
 
         if messages.is_empty() && exit_code != Some(0) {
             let mut command = args.to_command();
@@ -229,12 +257,20 @@ fn fix(
         }
 
         let mut finalized_targets = false;
-        // Retire targets separately so their dependents can join the next wave.
+        let is_ready = |target: &BuildUnit| {
+            target_iterations.get(target).copied().unwrap_or_default() >= max_iterations
+                || build_unit_map.get(target).is_none_or(IndexMap::is_empty)
+        };
+        // Retire targets separately, but keep speculative same-package cohorts together.
         let targets: Vec<_> = active_targets
             .keys()
             .filter(|target| {
-                target_iterations.get(*target).copied().unwrap_or_default() >= max_iterations
-                    || build_unit_map.get(*target).is_none_or(IndexMap::is_empty)
+                is_ready(target)
+                    && (!speculative_leaf_batch
+                        || active_targets
+                            .keys()
+                            .filter(|peer| peer.package_id == target.package_id)
+                            .all(&is_ready))
             })
             .cloned()
             .collect();
@@ -264,12 +300,20 @@ fn fix(
             finalized_targets = true;
         }
 
+        if speculative_leaf_batch {
+            let mut active_packages = HashSet::new();
+            speculative_leaf_batch = active_targets
+                .keys()
+                .any(|target| !active_packages.insert(&target.package_id));
+        }
+
         if active_targets.is_empty() {
             retired_targets.clear();
+            speculative_leaf_batch = false;
         }
 
         let mut made_changes = false;
-        // Admit build units from one compiler snapshot only when their packages are independent.
+        // Admit independent packages and executable leaf targets from one compiler snapshot.
 
         for (build_unit, file_map) in build_unit_map {
             if seen.contains(&build_unit) {
@@ -295,35 +339,49 @@ fn fix(
                 seen.insert(build_unit);
             } else if !file_map.is_empty() {
                 let was_active = active_targets.contains_key(&build_unit);
+                if was_active
+                    && target_iterations
+                        .get(&build_unit)
+                        .copied()
+                        .unwrap_or_default()
+                        >= max_iterations
+                {
+                    continue;
+                }
 
                 if !args.dangerous_parallel_fixes && !was_active && !active_targets.is_empty() {
+                    if active_targets.keys().any(|active| {
+                        active.package_id == build_unit.package_id
+                            && (!parallel_leaf_targets
+                                || !active.is_executable_leaf()
+                                || !build_unit.is_executable_leaf())
+                    }) {
+                        continue;
+                    }
+
                     if active_targets
                         .keys()
-                        .any(|active| active.package_id == build_unit.package_id)
+                        .any(|active| active.package_id != build_unit.package_id)
                     {
-                        continue;
-                    }
-
-                    if package_graph_cache.is_none() {
-                        let metadata =
-                            package_metadata(&mut package_metadata_cache, &args.check_flags)?;
-                        package_graph_cache = Some(PackageGraph::load(metadata, &args.check_flags));
-                    }
-                    let Some(Some(graph)) = package_graph_cache.as_mut() else {
-                        continue;
-                    };
-
-                    let mut independent = true;
-                    for active in active_targets.keys() {
-                        if !graph
-                            .packages_are_independent(&active.package_id, &build_unit.package_id)
-                        {
-                            independent = false;
-                            break;
+                        if package_graph_cache.is_none() {
+                            let metadata =
+                                package_metadata(&mut package_metadata_cache, &args.check_flags)?;
+                            package_graph_cache =
+                                Some(PackageGraph::load(metadata, &args.check_flags));
                         }
-                    }
-                    if !independent {
-                        continue;
+                        let Some(Some(graph)) = package_graph_cache.as_mut() else {
+                            continue;
+                        };
+
+                        if active_targets.keys().any(|active| {
+                            active.package_id != build_unit.package_id
+                                && !graph.packages_are_independent(
+                                    &active.package_id,
+                                    &build_unit.package_id,
+                                )
+                        }) {
+                            continue;
+                        }
                     }
                 }
 
@@ -346,12 +404,18 @@ fn fix(
                     continue;
                 }
 
+                let joins_speculative_leaf_batch = parallel_leaf_targets
+                    && !was_active
+                    && active_targets
+                        .keys()
+                        .any(|active| active.package_id == build_unit.package_id);
                 let target_files = active_targets.entry(build_unit.clone()).or_default();
                 let changed = fix_errors(target_files, file_map, build_unit_errors)?;
                 if !changed && !was_active {
                     active_targets.shift_remove(&build_unit);
                 }
                 if changed {
+                    speculative_leaf_batch |= joins_speculative_leaf_batch;
                     *target_iterations.entry(build_unit.clone()).or_default() += 1;
                     if let Some(handles) = handles {
                         for handle in handles {
@@ -389,6 +453,7 @@ fn fix(
             claimed_files.clear();
             target_iterations.clear();
             retired_targets.clear();
+            speculative_leaf_batch = false;
             continue;
         }
     }

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -554,7 +554,7 @@ fn independent_packages_progress_while_another_retries() {
     ] {
         assert!(!p.read_file(path).contains("let mut"));
     }
-    assert_eq!(p.read_file("check.log").lines().count(), 4);
+    assert_eq!(p.read_file("check.log").lines().count(), 3);
     assert_eq!(
         crate::fix::rustc_invocations(&rustc_log, ["dependency", "consumer", "slow"]),
         [2, 3, 3]

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -678,10 +678,14 @@ fn rolling_wavefront_project() -> Project {
 }
 
 #[cargo_test]
-fn executable_leaf_targets_are_serialized() {
+fn executable_leaf_targets_batch_only_when_independence_is_assumed() {
     let fake_cargo = fake_cargo();
 
-    for (name, broken_code) in [("default", false), ("broken", true)] {
+    for (name, assume_independent, broken_code, expected_checks) in [
+        ("default", false, false, 3),
+        ("parallel", true, false, 2),
+        ("broken", true, true, 3),
+    ] {
         let p = project()
             .at(format!("leaf-targets-{name}"))
             .file(
@@ -700,6 +704,9 @@ fn executable_leaf_targets_are_serialized() {
         command.arg("fixit");
         command.arg("--bins");
         command.arg("--allow-no-vcs");
+        if assume_independent {
+            command.arg("--Zassume-independent-targets");
+        }
         if broken_code {
             command.arg("--broken-code");
         }
@@ -710,7 +717,7 @@ fn executable_leaf_targets_are_serialized() {
             .with_process_builder(command)
             .run();
 
-        assert_eq!(p.read_file("check.log").lines().count(), 3);
+        assert_eq!(p.read_file("check.log").lines().count(), expected_checks);
         for target in ["first", "second"] {
             assert!(!p.read_file(format!("src/bin/{target}.rs")).contains("let mut"));
         }
@@ -741,6 +748,7 @@ fn executable_leaf_targets_with_shared_sources_remain_serial() {
     command.arg("fixit");
     command.arg("--bins");
     command.arg("--allow-no-vcs");
+    command.arg("--Zassume-independent-targets");
     command.env("CARGO", fake_cargo.bin("fake-cargo"));
     command.env("FIXIT_REAL_CARGO", env!("CARGO"));
     command.env("FIXIT_CHECK_LOG", &check_log);
@@ -755,7 +763,7 @@ fn executable_leaf_targets_with_shared_sources_remain_serial() {
 }
 
 #[cargo_test]
-fn executable_leaf_targets_serialize_hidden_source_dependencies() {
+fn executable_leaf_targets_retry_serially_after_hidden_source_dependency() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("build.rs", interdependent_bin_build_script())
@@ -769,7 +777,7 @@ fn executable_leaf_targets_serialize_hidden_source_dependencies() {
         )
         .build();
 
-    p.cargo_("fixit --bins --jobs 1 --allow-no-vcs")
+    p.cargo_("fixit --bins --jobs 1 --allow-no-vcs --Zassume-independent-targets")
         .with_stderr_data(str![[r#"
 [CHECKING] foo v0.1.0
 [FIXED] src/bin/[..].rs (1 fix)
@@ -787,7 +795,7 @@ fn executable_leaf_targets_serialize_hidden_source_dependencies() {
 }
 
 #[cargo_test]
-fn leaf_target_fixes_preserve_retired_wavefront_targets() {
+fn speculative_leaf_failure_preserves_retired_wavefront_targets() {
     let p = rolling_wavefront_project();
     p.change_file(
         "consumer/src/lib.rs",
@@ -803,17 +811,19 @@ fn leaf_target_fixes_preserve_retired_wavefront_targets() {
         );
     }
 
-    p.cargo_("fixit --workspace --lib --bins --jobs 1 --allow-no-vcs")
-        .with_stderr_data(str![[r#"
+    p.cargo_(
+        "fixit --workspace --lib --bins --jobs 1 --allow-no-vcs --Zassume-independent-targets",
+    )
+    .with_stderr_data(str![[r#"
 [CHECKING] consumer v0.1.0
 [CHECKING] dependency v0.1.0
 [FIXED] dependency/src/lib.rs (1 fix)
+[FIXED] consumer/src/bin/[..].rs (1 fix)
 [CHECKING] slow v0.1.0
 [FIXED] slow/src/lib.rs (2 fixes)
-[FIXED] consumer/src/bin/[..].rs (1 fix)
 
 "#]])
-        .run();
+    .run();
 
     assert!(!p.read_file("dependency/src/lib.rs").contains("let mut"));
     assert!(!p.read_file("slow/src/lib.rs").contains("let mut"));

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -678,6 +678,187 @@ fn rolling_wavefront_project() -> Project {
 }
 
 #[cargo_test]
+fn executable_leaf_targets_are_serialized() {
+    let fake_cargo = fake_cargo();
+
+    for (name, broken_code) in [("default", false), ("broken", true)] {
+        let p = project()
+            .at(format!("leaf-targets-{name}"))
+            .file(
+                "src/bin/first.rs",
+                "fn main() { let mut value = 1; let _ = value; }\n",
+            )
+            .file(
+                "src/bin/second.rs",
+                "fn main() { let mut value = 2; let _ = value; }\n",
+            )
+            .build();
+        let check_log = p.root().join("check.log");
+
+        let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+        command.cwd(p.root());
+        command.arg("fixit");
+        command.arg("--bins");
+        command.arg("--allow-no-vcs");
+        if broken_code {
+            command.arg("--broken-code");
+        }
+        command.env("CARGO", fake_cargo.bin("fake-cargo"));
+        command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+        command.env("FIXIT_CHECK_LOG", &check_log);
+        cargo_test_support::execs()
+            .with_process_builder(command)
+            .run();
+
+        assert_eq!(p.read_file("check.log").lines().count(), 3);
+        for target in ["first", "second"] {
+            assert!(!p.read_file(format!("src/bin/{target}.rs")).contains("let mut"));
+        }
+    }
+}
+
+#[cargo_test]
+fn executable_leaf_targets_with_shared_sources_remain_serial() {
+    let fake_cargo = fake_cargo();
+    let p = project()
+        .file(
+            "src/shared.rs",
+            "pub fn shared() -> usize { let mut value = 1; value }\n",
+        )
+        .file(
+            "src/bin/first.rs",
+            "#[path = \"../shared.rs\"] mod shared;\nfn main() { let mut value = shared::shared(); let _ = value; }\n",
+        )
+        .file(
+            "src/bin/second.rs",
+            "#[path = \"../shared.rs\"] mod shared;\nfn main() { let mut value = shared::shared(); let _ = value; }\n",
+        )
+        .build();
+    let check_log = p.root().join("check.log");
+
+    let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+    command.cwd(p.root());
+    command.arg("fixit");
+    command.arg("--bins");
+    command.arg("--allow-no-vcs");
+    command.env("CARGO", fake_cargo.bin("fake-cargo"));
+    command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+    command.env("FIXIT_CHECK_LOG", &check_log);
+    cargo_test_support::execs()
+        .with_process_builder(command)
+        .run();
+
+    assert_eq!(p.read_file("check.log").lines().count(), 3);
+    for path in ["src/shared.rs", "src/bin/first.rs", "src/bin/second.rs"] {
+        assert!(!p.read_file(path).contains("let mut"));
+    }
+}
+
+#[cargo_test]
+fn executable_leaf_targets_serialize_hidden_source_dependencies() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("build.rs", interdependent_bin_build_script())
+        .file(
+            "src/bin/first.rs",
+            "use std::mem::replace;\n\ninclude!(concat!(env!(\"OUT_DIR\"), \"/first.rs\"));\n\nfn main() { generated(); }\n",
+        )
+        .file(
+            "src/bin/second.rs",
+            "use std::mem::replace;\n\ninclude!(concat!(env!(\"OUT_DIR\"), \"/second.rs\"));\n\nfn main() { generated(); }\n",
+        )
+        .build();
+
+    p.cargo_("fixit --bins --jobs 1 --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.1.0
+[FIXED] src/bin/[..].rs (1 fix)
+
+"#]])
+        .run();
+
+    assert_ne!(
+        p.read_file("src/bin/first.rs")
+            .contains("use std::mem::replace;"),
+        p.read_file("src/bin/second.rs")
+            .contains("use std::mem::replace;"),
+    );
+    p.cargo_("check --bins").run();
+}
+
+#[cargo_test]
+fn leaf_target_fixes_preserve_retired_wavefront_targets() {
+    let p = rolling_wavefront_project();
+    p.change_file(
+        "consumer/src/lib.rs",
+        "pub fn consumer() -> usize { dependency::dependency() }\n",
+    );
+    p.change_file("consumer/build.rs", interdependent_bin_build_script());
+    for target in ["first", "second"] {
+        p.change_file(
+            format!("consumer/src/bin/{target}.rs"),
+            &format!(
+                "use std::mem::replace;\ninclude!(concat!(env!(\"OUT_DIR\"), \"/{target}.rs\"));\nfn main() {{ generated(); }}\n"
+            ),
+        );
+    }
+
+    p.cargo_("fixit --workspace --lib --bins --jobs 1 --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] consumer v0.1.0
+[CHECKING] dependency v0.1.0
+[FIXED] dependency/src/lib.rs (1 fix)
+[CHECKING] slow v0.1.0
+[FIXED] slow/src/lib.rs (2 fixes)
+[FIXED] consumer/src/bin/[..].rs (1 fix)
+
+"#]])
+        .run();
+
+    assert!(!p.read_file("dependency/src/lib.rs").contains("let mut"));
+    assert!(!p.read_file("slow/src/lib.rs").contains("let mut"));
+    assert_ne!(
+        p.read_file("consumer/src/bin/first.rs")
+            .contains("use std::mem::replace;"),
+        p.read_file("consumer/src/bin/second.rs")
+            .contains("use std::mem::replace;"),
+    );
+    p.cargo_("check --workspace --lib --bins").run();
+}
+
+fn interdependent_bin_build_script() -> &'static str {
+    r#"
+        use std::env;
+        use std::fs;
+        use std::path::Path;
+
+        fn main() {
+            let first = fs::read_to_string("src/bin/first.rs").unwrap();
+            let second = fs::read_to_string("src/bin/second.rs").unwrap();
+            let imported = "use std::mem::replace;";
+            let empty = "pub fn generated() {}";
+            let used =
+                "pub fn generated() { let mut value = 0; let _ = replace(&mut value, 1); }";
+            let output = env::var_os("OUT_DIR").unwrap();
+            let output = Path::new(&output);
+
+            fs::write(
+                output.join("first.rs"),
+                if second.contains(imported) { empty } else { used },
+            )
+            .unwrap();
+            fs::write(
+                output.join("second.rs"),
+                if first.contains(imported) { empty } else { used },
+            )
+            .unwrap();
+            println!("cargo:rerun-if-changed=src/bin/first.rs");
+            println!("cargo:rerun-if-changed=src/bin/second.rs");
+        }
+    "#
+}
+
+#[cargo_test]
 fn hardlinked_workspace_packages() {
     let original = "pub fn sample() -> usize { let mut value = 1; value }\n";
     let fixed = "pub fn sample() -> usize { let value = 1; value }\n";

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -124,13 +124,25 @@ metadata
 
 fn fake_cargo() -> Project {
     let fake_cargo = project()
-        .at(cargo_test_support::paths::global_root().join("fake-cargo"))
+        .at("fake-cargo")
         .file("Cargo.toml", &basic_manifest("fake-cargo", "1.0.0"))
         .file(
             "src/main.rs",
             r#"
             fn main() {
                 let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+                if args.first().is_some_and(|arg| arg == "check") {
+                    if let Some(log) = std::env::var_os("FIXIT_CHECK_LOG") {
+                        use std::io::Write as _;
+
+                        let mut log = std::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(log)
+                            .unwrap();
+                        writeln!(log, "check").unwrap();
+                    }
+                }
                 if args.first().is_some_and(|arg| arg == "metadata") {
                     if let Some(log) = std::env::var_os("FIXIT_METADATA_LOG") {
                         let args = args
@@ -511,6 +523,158 @@ fn independent_workspace_packages() {
             format!("pub fn {name}() {{ let value = 1; let _ = value; }}\n")
         );
     }
+}
+
+#[cargo_test]
+fn independent_packages_progress_while_another_retries() {
+    let fake_cargo = fake_cargo();
+    let p = rolling_wavefront_project();
+    let check_log = p.root().join("check.log");
+    let rustc_log = p.root().join("rustc.log");
+    std::fs::create_dir_all(&rustc_log).unwrap();
+
+    let mut command = cargo_test_support::process(env!("CARGO_BIN_EXE_cargo-fixit"));
+    command.cwd(p.root());
+    command.arg("fixit");
+    command.arg("--workspace");
+    command.arg("--allow-no-vcs");
+    command.env("CARGO", fake_cargo.bin("fake-cargo"));
+    command.env("FIXIT_REAL_CARGO", env!("CARGO"));
+    command.env("FIXIT_CHECK_LOG", &check_log);
+    command.env("RUSTC_WORKSPACE_WRAPPER", crate::fix::echo_wrapper());
+    command.env("__CARGO_FIXIT_RUSTC_LOG", &rustc_log);
+    cargo_test_support::execs()
+        .with_process_builder(command)
+        .run();
+
+    for path in [
+        "dependency/src/lib.rs",
+        "consumer/src/lib.rs",
+        "slow/src/lib.rs",
+    ] {
+        assert!(!p.read_file(path).contains("let mut"));
+    }
+    assert_eq!(p.read_file("check.log").lines().count(), 4);
+    assert_eq!(
+        crate::fix::rustc_invocations(&rustc_log, ["dependency", "consumer", "slow"]),
+        [2, 3, 3]
+    );
+}
+
+#[cargo_test]
+fn rolling_wavefront_restores_retired_packages_on_failure() {
+    let p = rolling_wavefront_project();
+    let original_dependency = p.read_file("dependency/src/lib.rs");
+    let original_consumer = p.read_file("consumer/src/lib.rs");
+    let original_slow = p.read_file("slow/src/lib.rs");
+
+    p.cargo_("fixit --workspace --allow-no-vcs")
+        .env("FIXIT_BREAK_AFTER_FIXES", "1")
+        .with_status(101)
+        .with_stderr_contains("[NOTE] reverting `dependency/src/lib.rs` to its original state")
+        .run();
+
+    assert_eq!(p.read_file("dependency/src/lib.rs"), original_dependency);
+    assert_eq!(p.read_file("consumer/src/lib.rs"), original_consumer);
+    assert_eq!(p.read_file("slow/src/lib.rs"), original_slow);
+}
+
+#[cargo_test]
+fn rolling_wavefront_restores_shared_files_in_reverse_order() {
+    let p = rolling_wavefront_project();
+    p.change_file(
+        "dependency/Cargo.toml",
+        &format!(
+            "{}\n[features]\ndefault = ['first']\nfirst = []\nsecond = []\n",
+            basic_manifest("dependency", "0.1.0")
+        ),
+    );
+    p.change_file(
+        "dependency/src/lib.rs",
+        "#[cfg(feature = \"first\")]\npub fn dependency() -> usize { let mut first = 1; first }\n\n#[cfg(feature = \"second\")]\npub fn shared() -> usize { let mut second = 1; second }\n",
+    );
+    p.change_file(
+        "consumer/Cargo.toml",
+        &format!(
+            "{}\n[features]\ndefault = ['second']\nfirst = []\nsecond = []\n\n[dependencies]\ndependency = {{ path = '../dependency' }}\n",
+            basic_manifest("consumer", "0.1.0")
+        ),
+    );
+    p.change_file(
+        "consumer/src/lib.rs",
+        "#[path = \"../../dependency/src/lib.rs\"]\nmod shared;\npub fn consumer() -> usize { dependency::dependency() + shared::shared() }\n",
+    );
+    let original_shared = p.read_file("dependency/src/lib.rs");
+
+    p.cargo_("fixit --workspace --allow-no-vcs")
+        .env("FIXIT_BREAK_AFTER_FIXES", "1")
+        .with_status(101)
+        .with_stderr_contains("[NOTE] reverting `dependency/src/lib.rs` to its original state")
+        .run();
+
+    assert_eq!(p.read_file("dependency/src/lib.rs"), original_shared);
+}
+
+fn rolling_wavefront_project() -> Project {
+    project()
+        .file(
+            "Cargo.toml",
+            "[workspace]\nmembers = ['dependency', 'consumer', 'slow']\nresolver = '2'\n",
+        )
+        .file("dependency/Cargo.toml", &basic_manifest("dependency", "0.1.0"))
+        .file(
+            "dependency/src/lib.rs",
+            "pub fn dependency() -> usize { let mut value = 1; value }\n",
+        )
+        .file(
+            "consumer/Cargo.toml",
+            &format!(
+                "{}\n[dependencies]\ndependency = {{ path = '../dependency' }}\n",
+                basic_manifest("consumer", "0.1.0")
+            ),
+        )
+        .file(
+            "consumer/src/lib.rs",
+            "pub fn consumer() -> usize { let mut value = dependency::dependency(); value }\n",
+        )
+        .file("slow/Cargo.toml", &basic_manifest("slow", "0.1.0"))
+        .file(
+            "slow/build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-check-cfg=cfg(fixit_first)");
+                    println!("cargo:rustc-check-cfg=cfg(fixit_second)");
+                    println!("cargo:rustc-check-cfg=cfg(fixit_broken)");
+                    println!("cargo:rerun-if-changed=src/lib.rs");
+
+                    let source = std::fs::read_to_string("src/lib.rs").unwrap();
+                    if source.contains("let mut first") {
+                        println!("cargo:rustc-cfg=fixit_first");
+                    } else if source.contains("let mut second") {
+                        println!("cargo:rustc-cfg=fixit_second");
+                    } else if std::env::var_os("FIXIT_BREAK_AFTER_FIXES").is_some() {
+                        println!("cargo:rustc-cfg=fixit_broken");
+                    }
+                }
+            "#,
+        )
+        .file(
+            "slow/src/lib.rs",
+            r#"
+                #[cfg(fixit_first)]
+                pub fn slow() -> usize { let mut first = 1; first }
+
+                #[cfg(fixit_second)]
+                pub fn slow() -> usize { let mut second = 1; second }
+
+                #[cfg(not(any(fixit_first, fixit_second)))]
+                pub fn slow() -> usize { 1 }
+
+                #[cfg(fixit_broken)]
+                pub fn broken() -> usize { missing_value() }
+            "#,
+        )
+        .build()
 }
 
 #[cargo_test]

--- a/tests/testsuite/help/stdout.term.svg
+++ b/tests/testsuite/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="995px" height="992px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1012px" height="1010px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -26,103 +26,105 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      --clippy                     Run `clippy` instead of `check`</tspan>
+    <tspan x="10px" y="118px"><tspan>      --clippy                       Run `clippy` instead of `check`</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      --broken-code                Fix code even if it already has compiler errors</tspan>
+    <tspan x="10px" y="136px"><tspan>      --broken-code                  Fix code even if it already has compiler errors</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      --Zdangerous-parallel-fixes  Fix all targets together, risking stale suggestions</tspan>
+    <tspan x="10px" y="154px"><tspan>      --Zassume-independent-targets  Assume executable targets are independent (stale fixes may change behavior)</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --color &lt;WHEN&gt;               Controls when to use color [default: auto] [possible values: auto, always, never]</tspan>
+    <tspan x="10px" y="172px"><tspan>      --Zdangerous-parallel-fixes    Fix all targets together, risking stale suggestions</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --allow-no-vcs               Fix code even if a VCS was not detected</tspan>
+    <tspan x="10px" y="190px"><tspan>      --color &lt;WHEN&gt;                 Controls when to use color [default: auto] [possible values: auto, always, never]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --allow-dirty                Fix code even if the working directory is dirty or has staged changes</tspan>
+    <tspan x="10px" y="208px"><tspan>      --allow-no-vcs                 Fix code even if a VCS was not detected</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      --allow-staged               Fix code even if the working directory has staged changes</tspan>
+    <tspan x="10px" y="226px"><tspan>      --allow-dirty                  Fix code even if the working directory is dirty or has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  -Z &lt;FLAG&gt;                        Unstable (nightly-only) flags</tspan>
+    <tspan x="10px" y="244px"><tspan>      --allow-staged                 Fix code even if the working directory has staged changes</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  -h, --help                       Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  -Z &lt;FLAG&gt;                          Unstable (nightly-only) flags</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  -V, --version                    Print version</tspan>
+    <tspan x="10px" y="280px"><tspan>  -h, --help                         Print help</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>  -V, --version                      Print version</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>Package Selection:</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  -p, --package &lt;SPEC&gt;  Package(s) to fix</tspan>
+    <tspan x="10px" y="334px"><tspan>Package Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
+    <tspan x="10px" y="352px"><tspan>  -p, --package &lt;SPEC&gt;  Package(s) to fix</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
+    <tspan x="10px" y="370px"><tspan>      --workspace       Fix all packages in the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
+    <tspan x="10px" y="388px"><tspan>      --exclude &lt;SPEC&gt;  Exclude packages from the fixes</tspan>
 </tspan>
-    <tspan x="10px" y="406px">
+    <tspan x="10px" y="406px"><tspan>      --all             Alias for --workspace (deprecated)</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>Target Selection:</tspan>
+    <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      --lib             Fix only this package's library</tspan>
+    <tspan x="10px" y="442px"><tspan>Target Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      --bins            Fix all binaries</tspan>
+    <tspan x="10px" y="460px"><tspan>      --lib             Fix only this package's library</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
+    <tspan x="10px" y="478px"><tspan>      --bins            Fix all binaries</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      --examples        Fix all examples</tspan>
+    <tspan x="10px" y="496px"><tspan>      --bin &lt;NAME&gt;      Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
+    <tspan x="10px" y="514px"><tspan>      --examples        Fix all examples</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      --tests           Fix all tests</tspan>
+    <tspan x="10px" y="532px"><tspan>      --example &lt;NAME&gt;  Fix only the specified binary</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
+    <tspan x="10px" y="550px"><tspan>      --tests           Fix all tests</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      --benches         Fix all benches</tspan>
+    <tspan x="10px" y="568px"><tspan>      --test &lt;NAME&gt;     Fix only the specified test</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
+    <tspan x="10px" y="586px"><tspan>      --benches         Fix all benches</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      --all-targets     Fix all targets</tspan>
+    <tspan x="10px" y="604px"><tspan>      --bench &lt;NAME&gt;    Fix only the specified bench</tspan>
 </tspan>
-    <tspan x="10px" y="622px">
+    <tspan x="10px" y="622px"><tspan>      --all-targets     Fix all targets</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>Feature Selection:</tspan>
+    <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
+    <tspan x="10px" y="658px"><tspan>Feature Selection:</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      --all-features         Activate all available features</tspan>
+    <tspan x="10px" y="676px"><tspan>  -F, --features &lt;FEATURES&gt;  Space or comma separated list of features to activate</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
+    <tspan x="10px" y="694px"><tspan>      --all-features         Activate all available features</tspan>
 </tspan>
-    <tspan x="10px" y="712px">
+    <tspan x="10px" y="712px"><tspan>      --no-default-features  Do not activate the `default` feature</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>Compilation Options:</tspan>
+    <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      --jobs &lt;N&gt;                Number of parallel jobs, defaults to # of CPUs</tspan>
+    <tspan x="10px" y="748px"><tspan>Compilation Options:</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      --release                 Fix artifacts in release mode, with optimizations</tspan>
+    <tspan x="10px" y="766px"><tspan>      --jobs &lt;N&gt;                Number of parallel jobs, defaults to # of CPUs</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      --profile &lt;PROFILE-NAME&gt;  Build artifacts with the specified profile</tspan>
+    <tspan x="10px" y="784px"><tspan>      --release                 Fix artifacts in release mode, with optimizations</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      --target &lt;TRIPLE&gt;         Fix for the target triple</tspan>
+    <tspan x="10px" y="802px"><tspan>      --profile &lt;PROFILE-NAME&gt;  Build artifacts with the specified profile</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      --target-dir &lt;DIRECTORY&gt;  Directory for all generated artifacts</tspan>
+    <tspan x="10px" y="820px"><tspan>      --target &lt;TRIPLE&gt;         Fix for the target triple</tspan>
 </tspan>
-    <tspan x="10px" y="838px">
+    <tspan x="10px" y="838px"><tspan>      --target-dir &lt;DIRECTORY&gt;  Directory for all generated artifacts</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>Manifest Options:</tspan>
+    <tspan x="10px" y="856px">
 </tspan>
-    <tspan x="10px" y="874px"><tspan>      --manifest-path &lt;PATH&gt;  Path to Cargo.toml</tspan>
+    <tspan x="10px" y="874px"><tspan>Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      --lockfile-path &lt;PATH&gt;  Path to Cargo.lock (unstable)</tspan>
+    <tspan x="10px" y="892px"><tspan>      --manifest-path &lt;PATH&gt;  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      --ignore-rust-version   Ignore `rust-version` specification in packages</tspan>
+    <tspan x="10px" y="910px"><tspan>      --lockfile-path &lt;PATH&gt;  Path to Cargo.lock (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      --locked                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="928px"><tspan>      --ignore-rust-version   Ignore `rust-version` specification in packages</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      --offline               Run without accessing the network</tspan>
+    <tspan x="10px" y="946px"><tspan>      --locked                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      --frozen                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="964px"><tspan>      --offline               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="982px">
+    <tspan x="10px" y="982px"><tspan>      --frozen                Equivalent to specifying both --locked and --offline</tspan>
+</tspan>
+    <tspan x="10px" y="1000px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary

Add an explicitly opt-in `--Zassume-independent-targets` mode that fixes binary-shaped bins, examples, tests, and benchmarks from the same package together. Ordinary `cargo fixit` behavior is unchanged.

This PR is stacked on #145. Its additional commits first capture the existing serialized behavior, then introduce opt-in target batching and update those expectations.

Libraries, build scripts, procedural macros, shared physical files, and package dependency ordering retain their existing scheduling barriers. Failed compiler verification rolls back the speculative batch and retries with the existing serial scheduler.

## Why opt in?

The physical-file check catches two fixes writing the same file; it does not catch one target writing a file another target reads. Stable Cargo diagnostics do not expose those read dependencies.

For example, one binary can remove an unused trait import from a source file that another binary reads with `include!`. A second trait import in the reading binary may be unused in the original compiler snapshot but become necessary after the first edit. Applying both stale suggestions still compiles, but method lookup can silently select a different implementation.

`#[path]`, build scripts, and procedural macros create the same hidden read/write dependency. This risk also exists across packages; the existing same-file guard cannot detect it. Until Cargo exposes authoritative target read sets, the optimization remains an explicit assumption rather than a default behavior change.

## Benchmarks

Independent binary targets in one package, comparing the same release binary with the flag disabled versus enabled:

| Binary targets | Default median | Opt-in median | Cargo checks | rustc calls | Improvement |
| --- | ---: | ---: | ---: | ---: | ---: |
| 2 | 308.7 ms | 222.7 ms | 3 → 2 | 4 → 4 | 27.9% |
| 8 | 897.9 ms | 346.8 ms | 9 → 2 | 16 → 16 | 61.4% |
| 16 | 1,815.3 ms | 564.9 ms | 17 → 2 | 32 → 32 | 68.9% |

Seven timed runs after warmup on macOS 26.6 arm64 with Rust 1.96.0; sources were restored between runs, Cargo's incremental cache remained warm, and variant order rotated between rounds.

Related: #52.
