### PR TITLE
perf: Build bins/test/benches/examples in parallel 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "anstream",
  "anyhow",
  "automod",
+ "camino",
  "cargo-test-support",
  "cargo-util",
  "cargo-util-schemas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ git2 = "0.20.4"
 glob = "0.3.3"
 cargo-util-schemas = "0.14.0"
 colorchoice-clap = "1.0.8"
+camino = "1.2.5"
 
 [dev-dependencies]
 automod = "1.0.17"

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -72,6 +72,11 @@ impl FixitArgs {
 }
 
 #[derive(Debug, Default)]
+struct ActiveState {
+    snapshots: IndexMap<String, File>,
+}
+
+#[derive(Debug, Default)]
 struct File {
     fixes: u32,
     original_source: String,
@@ -91,7 +96,10 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     match fix(&args, &mut active_units) {
         Ok(()) => Ok(()),
         Err(error) => {
-            for (file, original) in active_units.values().flat_map(|files| files.iter()) {
+            for (file, original) in active_units
+                .values()
+                .flat_map(|state| state.snapshots.iter())
+            {
                 paths::write(file, &original.original_source)?;
             }
             Err(error)
@@ -99,10 +107,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     }
 }
 
-fn fix(
-    args: &FixitArgs,
-    active_units: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
-) -> CargoResult<()> {
+fn fix(args: &FixitArgs, active_units: &mut IndexMap<BuildUnit, ActiveState>) -> CargoResult<()> {
     let max_iterations: usize = env::var("CARGO_FIX_MAX_RETRIES")
         .ok()
         .and_then(|i| i.parse().ok())
@@ -143,7 +148,9 @@ fn fix(
                         fixes: _,
                         original_source,
                     },
-                ) in active_units.values().flat_map(|files| files.iter())
+                ) in active_units
+                    .values()
+                    .flat_map(|state| state.snapshots.iter())
                 {
                     out.push_str(&format!("  * {file}\n"));
                     shell::note(format!("reverting `{file}` to its original state"))?;
@@ -324,8 +331,8 @@ fn fix(
                     continue;
                 }
 
-                let target_files = active_units.entry(build_unit.clone()).or_default();
-                let changed = fix_errors(unit_suggestions, target_files, build_unit_errors)?;
+                let state = active_units.entry(build_unit.clone()).or_default();
+                let changed = fix_errors(unit_suggestions, state, build_unit_errors)?;
                 if !changed && !was_active {
                     active_units.shift_remove(&build_unit);
                 }
@@ -363,8 +370,8 @@ fn fix(
         }
     }
 
-    for files in active_units.values() {
-        for (name, file) in files {
+    for state in active_units.values() {
+        for (name, file) in &state.snapshots {
             shell::fixed(name, file.fixes)?;
         }
     }
@@ -629,7 +636,7 @@ impl PackageGraph {
 /// Marks a target complete after reporting its fixes and remaining diagnostics.
 fn finish_unit(
     unit: BuildUnit,
-    active_units: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+    active_units: &mut IndexMap<BuildUnit, ActiveState>,
     errors: &mut BuildUnitErrors,
     seen: &mut HashSet<BuildUnit>,
 ) -> CargoResult<()> {
@@ -640,8 +647,8 @@ fn finish_unit(
         shell::status("Checking", format_package_id(&unit.package_id)?)?;
     }
 
-    if let Some(files) = active_units.get(&unit) {
-        for (name, file) in files {
+    if let Some(state) = active_units.get(&unit) {
+        for (name, file) in &state.snapshots {
             shell::fixed(name, file.fixes)?;
         }
     }
@@ -870,7 +877,7 @@ fn collect_errors(
 #[tracing::instrument(skip_all)]
 fn fix_errors(
     unit_suggestions: IndexMap<String, IndexSet<(Suggestion, Option<String>)>>,
-    files: &mut IndexMap<String, File>,
+    state: &mut ActiveState,
     errors: &mut IndexSet<String>,
 ) -> CargoResult<bool> {
     let mut made_changes = false;
@@ -903,7 +910,7 @@ fn fix_errors(
         }
         if fixed.modified() {
             let new_source = fixed.finish()?;
-            let file_state = files.entry(file.clone()).or_insert(File {
+            let file_state = state.snapshots.entry(file.clone()).or_insert(File {
                 fixes: 0,
                 original_source: source,
             });

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -112,10 +112,11 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
-    let mut package_metadata_cache = None;
     let mut primary_packages_cache = None;
     let mut package_graph_cache: Option<Option<PackageGraph>> = None;
     let mut seen = HashSet::new();
+
+    let package_metadata = package_metadata(&args.check_flags)?;
 
     loop {
         trace!("iteration={iteration}");
@@ -207,9 +208,10 @@ fn fix(
             let primary_packages = if let Some(primary_packages) = &primary_packages_cache {
                 primary_packages
             } else {
-                let metadata = package_metadata(&mut package_metadata_cache, &args.check_flags)?;
-                primary_packages_cache
-                    .insert(PrimaryPackages::from_metadata(metadata, &args.check_flags)?)
+                primary_packages_cache.insert(PrimaryPackages::from_metadata(
+                    &package_metadata,
+                    &args.check_flags,
+                )?)
             };
             retain_primary_fixes(primary_packages, &mut errors, &mut build_unit_map);
         }
@@ -294,9 +296,8 @@ fn fix(
                     }
 
                     if package_graph_cache.is_none() {
-                        let metadata =
-                            package_metadata(&mut package_metadata_cache, &args.check_flags)?;
-                        package_graph_cache = Some(PackageGraph::load(metadata, &args.check_flags));
+                        package_graph_cache =
+                            Some(PackageGraph::load(&package_metadata, &args.check_flags));
                     }
                     let Some(Some(graph)) = package_graph_cache.as_mut() else {
                         continue;
@@ -496,20 +497,12 @@ fn package_id_matches(spec: &PackageIdSpec, package_id: &PackageIdSpec) -> bool 
 }
 
 /// Loads unresolved package metadata once and reuses it for selection and ordering.
-fn package_metadata<'a>(
-    cache: &'a mut Option<Metadata>,
-    flags: &CheckFlags,
-) -> CargoResult<&'a Metadata> {
-    match cache {
-        Some(metadata) => Ok(metadata),
-        cache @ None => {
-            let mut command = MetadataCommand::new();
-            command.no_deps();
-            command.other_options(flags.to_metadata_flags());
-            let metadata = command.exec().context("failed to run `cargo metadata`")?;
-            Ok(cache.insert(metadata))
-        }
-    }
+fn package_metadata(flags: &CheckFlags) -> CargoResult<Metadata> {
+    let mut command = MetadataCommand::new();
+    command.no_deps();
+    command.other_options(flags.to_metadata_flags());
+    let metadata = command.exec().context("failed to run `cargo metadata`")?;
+    Ok(metadata)
 }
 
 /// Discards dependency suggestions while preserving their diagnostics for display.

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -87,11 +87,11 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
     args.vcs_opts.valid_vcs()?;
 
-    let mut active_targets = IndexMap::new();
-    match fix(&args, &mut active_targets) {
+    let mut active_units = IndexMap::new();
+    match fix(&args, &mut active_units) {
         Ok(()) => Ok(()),
         Err(error) => {
-            for (file, original) in active_targets.values().flat_map(|files| files.iter()) {
+            for (file, original) in active_units.values().flat_map(|files| files.iter()) {
                 paths::write(file, &original.original_source)?;
             }
             Err(error)
@@ -101,7 +101,7 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
 
 fn fix(
     args: &FixitArgs,
-    active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+    active_units: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
 ) -> CargoResult<()> {
     let max_iterations: usize = env::var("CARGO_FIX_MAX_RETRIES")
         .ok()
@@ -120,7 +120,7 @@ fn fix(
 
     loop {
         trace!("iteration={iteration}");
-        trace!("active_targets={active_targets:?}");
+        trace!("active_units={active_units:?}");
         let (mut messages, exit_code) = check(args, &mut lint_cap)?;
         messages.sort_unstable_by_key(|m| m.build_unit().cloned());
         print_built(args, &messages)?;
@@ -132,7 +132,7 @@ fn fix(
         } else if !args.broken_code && exit_code != Some(0) {
             let mut out = String::new();
 
-            if !active_targets.is_empty() {
+            if !active_units.is_empty() {
                 out.push_str(
                     "failed to automatically apply fixes suggested by rustc\n\n\
                     after fixes were automatically applied the \
@@ -145,13 +145,13 @@ fn fix(
                         fixes: _,
                         original_source,
                     },
-                ) in active_targets.values().flat_map(|files| files.iter())
+                ) in active_units.values().flat_map(|files| files.iter())
                 {
                     out.push_str(&format!("  * {file}\n"));
                     shell::note(format!("reverting `{file}` to its original state"))?;
                     paths::write(file, original_source)?;
                 }
-                active_targets.clear();
+                active_units.clear();
                 out.push('\n');
 
                 out.push_str(&gen_please_report_this_bug_text(args.clippy));
@@ -207,10 +207,10 @@ fn fix(
             collect_errors(messages.into_iter(), &seen, &primary_packages);
 
         if iteration >= max_iterations {
-            if active_targets.is_empty() {
+            if active_units.is_empty() {
                 break;
             }
-            let targets: Vec<_> = active_targets.keys().cloned().collect();
+            let targets: Vec<_> = active_units.keys().cloned().collect();
             for target in targets {
                 if let Some(file_map) = build_unit_map.get(&target) {
                     let target_errors = errors.entry(target.clone()).or_default();
@@ -221,24 +221,24 @@ fn fix(
                             .filter_map(|(_, diagnostic)| diagnostic.clone()),
                     );
                 }
-                finish_target(target, active_targets, &mut errors, &mut seen)?;
+                finish_unit(target, active_units, &mut errors, &mut seen)?;
             }
             claimed_files.clear();
             iteration = 0;
         }
 
         let mut finalized_targets = false;
-        if !active_targets.is_empty()
-            && active_targets
+        if !active_units.is_empty()
+            && active_units
                 .keys()
                 .all(|target| build_unit_map.get(target).is_none_or(IndexMap::is_empty))
         {
-            let targets: Vec<_> = active_targets.keys().cloned().collect();
+            let targets: Vec<_> = active_units.keys().cloned().collect();
             for target in targets {
                 build_unit_map.shift_remove(&target);
-                finish_target(target, active_targets, &mut errors, &mut seen)?;
+                finish_unit(target, active_units, &mut errors, &mut seen)?;
             }
-            debug_assert!(active_targets.is_empty());
+            debug_assert!(active_units.is_empty());
             claimed_files.clear();
             iteration = 0;
             finalized_targets = true;
@@ -247,7 +247,7 @@ fn fix(
         let mut made_changes = false;
         // Admit build units from one compiler snapshot only when their packages are independent.
         // Once a batch is active, recheck and finish it before considering additional units.
-        let continuing_batch = !active_targets.is_empty();
+        let continuing_batch = !active_units.is_empty();
 
         for (build_unit, file_map) in build_unit_map {
             if seen.contains(&build_unit) {
@@ -258,7 +258,7 @@ fn fix(
                 .entry(build_unit.clone())
                 .or_insert_with(IndexSet::new);
 
-            if active_targets.is_empty() && file_map.is_empty() {
+            if active_units.is_empty() && file_map.is_empty() {
                 if finalized_targets && build_unit_errors.is_empty() {
                     continue;
                 }
@@ -272,13 +272,13 @@ fn fix(
 
                 seen.insert(build_unit);
             } else if !file_map.is_empty() {
-                let was_active = active_targets.contains_key(&build_unit);
+                let was_active = active_units.contains_key(&build_unit);
                 if continuing_batch && !was_active {
                     continue;
                 }
 
-                if !args.dangerous_parallel_fixes && !was_active && !active_targets.is_empty() {
-                    if active_targets
+                if !args.dangerous_parallel_fixes && !was_active && !active_units.is_empty() {
+                    if active_units
                         .keys()
                         .any(|active| active.package_id == build_unit.package_id)
                     {
@@ -294,7 +294,7 @@ fn fix(
                     };
 
                     let mut independent = true;
-                    for active in active_targets.keys() {
+                    for active in active_units.keys() {
                         if !graph
                             .packages_are_independent(&active.package_id, &build_unit.package_id)
                         {
@@ -313,7 +313,7 @@ fn fix(
                     .collect::<Result<Vec<_>, _>>()
                     .ok();
                 let serialize_target = handles.is_none();
-                if serialize_target && !was_active && !active_targets.is_empty() {
+                if serialize_target && !was_active && !active_units.is_empty() {
                     continue;
                 }
                 if handles.as_ref().is_some_and(|handles| {
@@ -326,10 +326,10 @@ fn fix(
                     continue;
                 }
 
-                let target_files = active_targets.entry(build_unit.clone()).or_default();
+                let target_files = active_units.entry(build_unit.clone()).or_default();
                 let changed = fix_errors(target_files, file_map, build_unit_errors)?;
                 if !changed && !was_active {
-                    active_targets.shift_remove(&build_unit);
+                    active_units.shift_remove(&build_unit);
                 }
                 if changed {
                     if let Some(handles) = handles {
@@ -346,18 +346,18 @@ fn fix(
         }
 
         trace!("made_changes={made_changes:?}");
-        trace!("active_targets={active_targets:?}");
+        trace!("active_units={active_units:?}");
 
         last_errors = errors;
         iteration += 1;
 
         if !made_changes {
-            if active_targets.is_empty() {
+            if active_units.is_empty() {
                 break;
             }
-            let targets: Vec<_> = active_targets.keys().cloned().collect();
+            let targets: Vec<_> = active_units.keys().cloned().collect();
             for target in targets {
-                finish_target(target, active_targets, &mut last_errors, &mut seen)?;
+                finish_unit(target, active_units, &mut last_errors, &mut seen)?;
             }
             claimed_files.clear();
             iteration = 0;
@@ -365,7 +365,7 @@ fn fix(
         }
     }
 
-    for files in active_targets.values() {
+    for files in active_units.values() {
         for (name, file) in files {
             shell::fixed(name, file.fixes)?;
         }
@@ -375,7 +375,7 @@ fn fix(
         shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
     }
 
-    active_targets.clear();
+    active_units.clear();
     Ok(())
 }
 
@@ -629,32 +629,32 @@ impl PackageGraph {
 }
 
 /// Marks a target complete after reporting its fixes and remaining diagnostics.
-fn finish_target(
-    target: BuildUnit,
-    active_targets: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
+fn finish_unit(
+    unit: BuildUnit,
+    active_units: &mut IndexMap<BuildUnit, IndexMap<String, File>>,
     errors: &mut BuildUnitErrors,
     seen: &mut HashSet<BuildUnit>,
 ) -> CargoResult<()> {
     if seen
         .iter()
-        .all(|build_unit| build_unit.package_id != target.package_id)
+        .all(|build_unit| build_unit.package_id != unit.package_id)
     {
-        shell::status("Checking", format_package_id(&target.package_id)?)?;
+        shell::status("Checking", format_package_id(&unit.package_id)?)?;
     }
 
-    if let Some(files) = active_targets.get(&target) {
+    if let Some(files) = active_units.get(&unit) {
         for (name, file) in files {
             shell::fixed(name, file.fixes)?;
         }
     }
 
-    for error in errors.get(&target).into_iter().flatten() {
+    for error in errors.get(&unit).into_iter().flatten() {
         shell::print_ansi_stderr(format!("{}\n\n", error.trim_end()).as_bytes())?;
     }
 
-    active_targets.shift_remove(&target);
-    errors.shift_remove(&target);
-    seen.insert(target);
+    active_units.shift_remove(&unit);
+    errors.shift_remove(&unit);
+    seen.insert(unit);
     Ok(())
 }
 

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -203,10 +203,8 @@ fn fix(
             anyhow::bail!("could not compile");
         }
 
-        let (mut errors, mut build_unit_map) = collect_errors(messages.into_iter(), &seen);
-        if build_unit_map.values().any(|file_map| !file_map.is_empty()) {
-            retain_primary_fixes(&primary_packages, &mut errors, &mut build_unit_map);
-        }
+        let (mut errors, mut build_unit_map) =
+            collect_errors(messages.into_iter(), &seen, &primary_packages);
 
         if iteration >= max_iterations {
             if active_targets.is_empty() {
@@ -497,28 +495,6 @@ fn package_metadata(flags: &CheckFlags) -> CargoResult<Metadata> {
     Ok(metadata)
 }
 
-/// Discards dependency suggestions while preserving their diagnostics for display.
-fn retain_primary_fixes(
-    primary_packages: &PrimaryPackages,
-    errors: &mut BuildUnitErrors,
-    build_unit_map: &mut BuildUnitSuggestions,
-) {
-    for (build_unit, file_map) in build_unit_map {
-        if file_map.is_empty() || primary_packages.contains(&build_unit.package_id) {
-            continue;
-        }
-
-        let build_unit_errors = errors.entry(build_unit.clone()).or_default();
-        build_unit_errors.extend(
-            file_map
-                .values()
-                .flatten()
-                .filter_map(|(_, diagnostic)| diagnostic.clone()),
-        );
-        file_map.clear();
-    }
-}
-
 /// Package dependencies used to batch only transitively unrelated packages.
 #[derive(Debug)]
 struct PackageGraph {
@@ -779,6 +755,7 @@ fn to_check_output(output: std::process::Output) -> (Vec<CheckOutput>, Option<i3
 fn collect_errors(
     messages: impl Iterator<Item = CheckOutput>,
     seen: &HashSet<BuildUnit>,
+    primary_packages: &PrimaryPackages,
 ) -> (BuildUnitErrors, BuildUnitSuggestions) {
     let only = HashSet::new();
     let mut build_unit_map = IndexMap::new();
@@ -807,6 +784,17 @@ fn collect_errors(
 
         if seen.contains(&build_unit) {
             trace!("rejecting build unit `{:?}` already seen", build_unit);
+            continue;
+        }
+
+        if !primary_packages.contains(&build_unit.package_id) {
+            trace!(
+                "rejecting build unit `{:?}` not selected by the user",
+                build_unit
+            );
+            if let Some(rendered) = diagnostic.rendered {
+                errors.insert(rendered);
+            }
             continue;
         }
 

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -107,17 +107,15 @@ fn fix(
         .ok()
         .and_then(|i| i.parse().ok())
         .unwrap_or(4);
-    let mut iteration = 0;
-    let mut lint_cap = false;
-
-    let mut last_errors = IndexMap::new();
-    let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
-    let mut package_graph_cache: Option<Option<PackageGraph>> = None;
-    let mut seen = HashSet::new();
-
     let package_metadata = package_metadata(&args.check_flags)?;
     let primary_packages = PrimaryPackages::from_metadata(&package_metadata, &args.check_flags)?;
+    let mut package_graph_cache: Option<Option<PackageGraph>> = None;
 
+    let mut iteration = 0;
+    let mut lint_cap = false;
+    let mut last_errors = IndexMap::new();
+    let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
+    let mut seen = HashSet::new();
     loop {
         trace!("iteration={iteration}");
         trace!("active_units={active_units:?}");

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -325,7 +325,7 @@ fn fix(
                 }
 
                 let target_files = active_units.entry(build_unit.clone()).or_default();
-                let changed = fix_errors(target_files, unit_suggestions, build_unit_errors)?;
+                let changed = fix_errors(unit_suggestions, target_files, build_unit_errors)?;
                 if !changed && !was_active {
                     active_units.shift_remove(&build_unit);
                 }
@@ -869,8 +869,8 @@ fn collect_errors(
 
 #[tracing::instrument(skip_all)]
 fn fix_errors(
-    files: &mut IndexMap<String, File>,
     unit_suggestions: IndexMap<String, IndexSet<(Suggestion, Option<String>)>>,
+    files: &mut IndexMap<String, File>,
     errors: &mut IndexSet<String>,
 ) -> CargoResult<bool> {
     let mut made_changes = false;

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -112,11 +112,11 @@ fn fix(
 
     let mut last_errors = IndexMap::new();
     let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
-    let mut primary_packages_cache = None;
     let mut package_graph_cache: Option<Option<PackageGraph>> = None;
     let mut seen = HashSet::new();
 
     let package_metadata = package_metadata(&args.check_flags)?;
+    let primary_packages = PrimaryPackages::from_metadata(&package_metadata, &args.check_flags)?;
 
     loop {
         trace!("iteration={iteration}");
@@ -205,15 +205,7 @@ fn fix(
 
         let (mut errors, mut build_unit_map) = collect_errors(messages.into_iter(), &seen);
         if build_unit_map.values().any(|file_map| !file_map.is_empty()) {
-            let primary_packages = if let Some(primary_packages) = &primary_packages_cache {
-                primary_packages
-            } else {
-                primary_packages_cache.insert(PrimaryPackages::from_metadata(
-                    &package_metadata,
-                    &args.check_flags,
-                )?)
-            };
-            retain_primary_fixes(primary_packages, &mut errors, &mut build_unit_map);
+            retain_primary_fixes(&primary_packages, &mut errors, &mut build_unit_map);
         }
 
         if iteration >= max_iterations {

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env;
@@ -22,7 +24,9 @@ use tracing::{trace, warn};
 use crate::util::cli::PackageSelection;
 use crate::{
     core::{shell, sysroot::get_sysroot},
-    ops::check::{BuildUnit, CheckOutput, DiagnosticLevel, Message, MessageDiagnostic, TargetKind},
+    ops::check::{
+        BuildUnit, CheckOutput, CrateType, DiagnosticLevel, Message, MessageDiagnostic, TargetKind,
+    },
     util::{
         cli::CheckFlags, messages::gen_please_report_this_bug_text, package::format_package_id,
         vcs::VcsOpts,
@@ -74,6 +78,7 @@ impl FixitArgs {
 #[derive(Debug, Default)]
 struct ActiveState {
     snapshots: IndexMap<String, File>,
+    iterations: usize,
 }
 
 #[derive(Debug, Default)]
@@ -82,9 +87,9 @@ struct File {
     original_source: String,
 }
 
-type BuildUnitErrors = IndexMap<BuildUnit, IndexSet<String>>;
+type BuildUnitErrors = IndexMap<UnitId, IndexSet<String>>;
 type BuildUnitSuggestions =
-    IndexMap<BuildUnit, IndexMap<String, IndexSet<(Suggestion, Option<String>)>>>;
+    IndexMap<UnitId, IndexMap<String, IndexSet<(Suggestion, Option<String>)>>>;
 
 #[tracing::instrument(skip_all)]
 fn exec(args: FixitArgs) -> CargoResult<()> {
@@ -107,23 +112,26 @@ fn exec(args: FixitArgs) -> CargoResult<()> {
     }
 }
 
-fn fix(args: &FixitArgs, active_units: &mut IndexMap<BuildUnit, ActiveState>) -> CargoResult<()> {
+fn fix(args: &FixitArgs, active_units: &mut IndexMap<UnitId, ActiveState>) -> CargoResult<()> {
     let max_iterations: usize = env::var("CARGO_FIX_MAX_RETRIES")
         .ok()
         .and_then(|i| i.parse().ok())
         .unwrap_or(4);
     let package_metadata = package_metadata(&args.check_flags)?;
     let primary_packages = PrimaryPackages::from_metadata(&package_metadata, &args.check_flags)?;
-    let mut package_graph_cache: Option<Option<PackageGraph>> = None;
+    let mut plan = if args.dangerous_parallel_fixes {
+        UnitGraph::flat(&package_metadata)
+    } else {
+        UnitGraph::new(&package_metadata)
+    };
+    trace!("plan `{plan:#?}`");
 
-    let mut iteration = 0;
     let mut lint_cap = false;
-    let mut last_errors = IndexMap::new();
-    let mut claimed_files: HashMap<same_file::Handle, BuildUnit> = HashMap::new();
-    let mut seen = HashSet::new();
+    let mut seen = BTreeSet::new();
+    let mut first = true;
+    let mut claimed_files: HashMap<same_file::Handle, UnitId> = HashMap::new();
     loop {
-        trace!("iteration={iteration}");
-        trace!("active_units={active_units:?}");
+        trace!("check ({active_units:?})");
         let (mut messages, exit_code) = check(args, &mut lint_cap)?;
         messages.sort_unstable_by_key(|m| m.build_unit().cloned());
         print_built(args, &messages)?;
@@ -207,180 +215,109 @@ fn fix(args: &FixitArgs, active_units: &mut IndexMap<BuildUnit, ActiveState>) ->
             shell::note("try using `--broken-code` to fix errors")?;
             anyhow::bail!("could not compile");
         }
-
-        let (mut errors, mut suggestions) =
-            collect_diagnostics(messages.into_iter(), &seen, &primary_packages);
-
-        if iteration >= max_iterations {
-            if active_units.is_empty() {
-                break;
-            }
-            let targets: Vec<_> = active_units.keys().cloned().collect();
-            for target in targets {
-                if let Some(unit_suggestions) = suggestions.get(&target) {
-                    let target_errors = errors.entry(target.clone()).or_default();
-                    target_errors.extend(
-                        unit_suggestions
-                            .values()
-                            .flatten()
-                            .filter_map(|(_, diagnostic)| diagnostic.clone()),
-                    );
+        if first {
+            first = false;
+            let mut errors = IndexMap::new();
+            for message in &messages {
+                match message {
+                    CheckOutput::Message(Message {
+                        build_unit,
+                        message: MessageDiagnostic { diagnostic, .. },
+                    }) => {
+                        let unit_id = UnitId::from_message(build_unit);
+                        if let Some(rendered) = diagnostic.rendered.clone() {
+                            let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
+                            errors.insert(rendered);
+                        }
+                    }
+                    CheckOutput::Artifact(a) => {
+                        let package_id = &a.build_unit.package_id;
+                        let unit_id = UnitId::from_message(&a.build_unit);
+                        if !is_local(package_id) || !plan.dependencies.contains_key(&unit_id) {
+                            for error in errors.get(&unit_id).into_iter().flatten() {
+                                shell::print_ansi_stderr(
+                                    format!("{}\n\n", error.trim_end()).as_bytes(),
+                                )?;
+                            }
+                            if !a.fresh && seen.insert(package_id.to_owned()) {
+                                shell::status("Checking", format_package_id(package_id)?)?;
+                            }
+                        }
+                    }
                 }
-                finish_unit(target, active_units, &mut errors, &mut seen)?;
             }
-            claimed_files.clear();
-            iteration = 0;
         }
 
-        let mut finalized_targets = false;
-        if !active_units.is_empty()
-            && active_units
-                .keys()
-                .all(|target| suggestions.get(target).is_none_or(IndexMap::is_empty))
-        {
-            let targets: Vec<_> = active_units.keys().cloned().collect();
-            for target in targets {
-                suggestions.shift_remove(&target);
-                finish_unit(target, active_units, &mut errors, &mut seen)?;
+        let observed_packages: HashSet<String> = messages
+            .iter()
+            .filter_map(CheckOutput::build_unit)
+            .map(|unit| unit.package_id.clone())
+            .collect();
+        let (mut errors, suggestions) = collect_diagnostics(
+            messages.into_iter(),
+            &plan.finished,
+            &primary_packages,
+            active_units,
+            max_iterations,
+        );
+
+        let mut finishing = true;
+        while finishing {
+            let mut finished = BTreeSet::new();
+            for unit_id in active_units.keys() {
+                if suggestions.contains_key(unit_id) {
+                    continue;
+                }
+                let errors = errors.shift_remove(unit_id);
+                finish_unit(unit_id, active_units, errors.as_ref())?;
+                finished.insert(unit_id.clone());
             }
-            debug_assert!(active_units.is_empty());
-            claimed_files.clear();
-            iteration = 0;
-            finalized_targets = true;
+            active_units.retain(|k, _v| !finished.contains(k));
+            claimed_files.retain(|_k, v| !finished.contains(v));
+            plan.mark_finished(finished);
+            finishing = false;
+            for unit_id in plan.take_ready() {
+                finishing = true;
+                trace!("scheduling `{unit_id:?}`");
+                let package_id = unit_id.package_id();
+                if observed_packages.contains(package_id) && seen.insert(package_id.to_owned()) {
+                    shell::status("Checking", format_package_id(package_id)?)?;
+                }
+                active_units.insert(unit_id, Default::default());
+            }
+        }
+        if active_units.is_empty() {
+            assert!(plan.is_empty(), "{plan:#?}");
+            break;
         }
 
-        let mut made_changes = false;
-        // Admit build units from one compiler snapshot only when their packages are independent.
-        // Once a batch is active, recheck and finish it before considering additional units.
-        let continuing_batch = !active_units.is_empty();
-
-        for (build_unit, unit_suggestions) in suggestions {
-            if seen.contains(&build_unit) {
-                continue;
-            }
-
-            let build_unit_errors = errors
-                .entry(build_unit.clone())
-                .or_insert_with(IndexSet::new);
-
-            if active_units.is_empty() && unit_suggestions.is_empty() {
-                if finalized_targets && build_unit_errors.is_empty() {
+        'units: for (unit_id, state) in active_units.iter_mut() {
+            let unit_suggestions = suggestions
+                .get(unit_id)
+                .expect("finished all active_units without suggestions");
+            for path in state.snapshots.keys().chain(unit_suggestions.keys()) {
+                let Ok(handle) = same_file::Handle::from_path(path) else {
                     continue;
-                }
-                if seen.iter().all(|b| b.package_id != build_unit.package_id) {
-                    shell::status("Checking", format_package_id(&build_unit.package_id)?)?;
-                }
-                for e in build_unit_errors.iter() {
-                    shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
-                }
-                errors.shift_remove(&build_unit);
-
-                seen.insert(build_unit);
-            } else if !unit_suggestions.is_empty() {
-                let was_active = active_units.contains_key(&build_unit);
-                if continuing_batch && !was_active {
-                    continue;
-                }
-
-                if !args.dangerous_parallel_fixes && !was_active && !active_units.is_empty() {
-                    if active_units
-                        .keys()
-                        .any(|active| active.package_id == build_unit.package_id)
+                };
+                match claimed_files.entry(handle) {
+                    std::collections::hash_map::Entry::Occupied(entry)
+                        if entry.get() != unit_id =>
                     {
-                        continue;
+                        trace!("deferring `{unit_id:?}` due to contention over {path}");
+                        claimed_files.retain(|_k, v| v != unit_id);
+                        continue 'units;
                     }
-
-                    if package_graph_cache.is_none() {
-                        package_graph_cache =
-                            Some(PackageGraph::load(&package_metadata, &args.check_flags));
-                    }
-                    let Some(Some(graph)) = package_graph_cache.as_mut() else {
-                        continue;
-                    };
-
-                    let mut independent = true;
-                    for active in active_units.keys() {
-                        if !graph
-                            .packages_are_independent(&active.package_id, &build_unit.package_id)
-                        {
-                            independent = false;
-                            break;
-                        }
-                    }
-                    if !independent {
-                        continue;
-                    }
-                }
-
-                let handles = unit_suggestions
-                    .keys()
-                    .map(same_file::Handle::from_path)
-                    .collect::<Result<Vec<_>, _>>()
-                    .ok();
-                let serialize_target = handles.is_none();
-                if serialize_target && !was_active && !active_units.is_empty() {
-                    continue;
-                }
-                if handles.as_ref().is_some_and(|handles| {
-                    handles.iter().any(|handle| {
-                        claimed_files
-                            .get(handle)
-                            .is_some_and(|owner| owner != &build_unit)
-                    })
-                }) {
-                    continue;
-                }
-
-                let state = active_units.entry(build_unit.clone()).or_default();
-                let changed = fix_suggestions(unit_suggestions, state, build_unit_errors)?;
-                if !changed && !was_active {
-                    active_units.shift_remove(&build_unit);
-                }
-                if changed {
-                    if let Some(handles) = handles {
-                        for handle in handles {
-                            claimed_files.entry(handle).or_insert(build_unit.clone());
-                        }
-                    }
-                    made_changes = true;
-                    if serialize_target {
-                        break;
+                    std::collections::hash_map::Entry::Occupied(_) => {}
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(unit_id.clone());
                     }
                 }
             }
-        }
-
-        trace!("made_changes={made_changes:?}");
-        trace!("active_units={active_units:?}");
-
-        last_errors = errors;
-        iteration += 1;
-
-        if !made_changes {
-            if active_units.is_empty() {
-                break;
-            }
-            let targets: Vec<_> = active_units.keys().cloned().collect();
-            for target in targets {
-                finish_unit(target, active_units, &mut last_errors, &mut seen)?;
-            }
-            claimed_files.clear();
-            iteration = 0;
-            continue;
+            trace!("fixing `{unit_id:?}` {state:?}");
+            state.iterations += 1;
+            let _made_changes = fix_suggestions(unit_suggestions, state)?;
         }
     }
-
-    for state in active_units.values() {
-        for (name, file) in &state.snapshots {
-            shell::fixed(name, file.fixes)?;
-        }
-    }
-
-    for e in last_errors.iter().flat_map(|(_, e)| e) {
-        shell::print_ansi_stderr(format!("{}\n\n", e.trim_end()).as_bytes())?;
-    }
-
-    active_units.clear();
     Ok(())
 }
 
@@ -500,166 +437,22 @@ fn package_metadata(flags: &CheckFlags) -> CargoResult<Metadata> {
     Ok(metadata)
 }
 
-/// Package dependencies used to batch only transitively unrelated packages.
-#[derive(Debug)]
-struct PackageGraph {
-    dependencies: HashMap<String, Vec<String>>,
-    reachable: HashMap<String, HashSet<String>>,
-}
-
-impl PackageGraph {
-    /// Loads the package graph, returning `None` when batching must remain serial.
-    fn load(metadata: &Metadata, flags: &CheckFlags) -> Option<Self> {
-        // A script is identified by its manifest path, not its containing directory.
-        if metadata
-            .packages
-            .iter()
-            .any(|package| package.manifest_path.file_name() != Some("Cargo.toml"))
-        {
-            return Self::load_resolved(flags);
-        }
-
-        let package_ids_by_path: HashMap<_, _> = metadata
-            .packages
-            .iter()
-            .filter_map(|package| {
-                package
-                    .manifest_path
-                    .parent()
-                    .map(|path| (path, package.id.repr.as_str()))
-            })
-            .collect();
-        if package_ids_by_path.len() != metadata.packages.len() {
-            return Self::load_resolved(flags);
-        }
-
-        let package_names: HashSet<_> = metadata
-            .packages
-            .iter()
-            .map(|package| package.name.as_ref())
-            .collect();
-        let mut dependencies = HashMap::with_capacity(metadata.packages.len());
-        for package in &metadata.packages {
-            let mut package_dependencies = Vec::new();
-            for dependency in &package.dependencies {
-                if let Some(path) = &dependency.path {
-                    let Some(dependency_id) = package_ids_by_path.get(path.as_path()) else {
-                        return Self::load_resolved(flags);
-                    };
-                    package_dependencies.push((*dependency_id).to_owned());
-                } else if package_names.contains(dependency.name.as_str()) {
-                    return Self::load_resolved(flags);
-                }
-            }
-            dependencies.insert(package.id.repr.clone(), package_dependencies);
-        }
-
-        Some(Self {
-            dependencies,
-            reachable: HashMap::new(),
-        })
-    }
-
-    /// Resolves external packages when workspace metadata cannot prove independence.
-    fn load_resolved(flags: &CheckFlags) -> Option<Self> {
-        let mut command = MetadataCommand::new();
-        command.other_options(flags.to_metadata_flags());
-
-        let metadata = match command.exec() {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                warn!("failed to run `cargo metadata`: {error}");
-                return None;
-            }
-        };
-        let Some(resolve) = metadata.resolve else {
-            warn!("`cargo metadata` did not return a dependency graph");
-            return None;
-        };
-        let dependencies = resolve
-            .nodes
-            .into_iter()
-            .map(|node| {
-                (
-                    node.id.repr,
-                    node.dependencies
-                        .into_iter()
-                        .map(|dependency| dependency.repr)
-                        .collect(),
-                )
-            })
-            .collect();
-
-        Some(Self {
-            dependencies,
-            reachable: HashMap::new(),
-        })
-    }
-
-    /// Returns whether both packages are known and transitively unrelated.
-    fn packages_are_independent(&mut self, left: &str, right: &str) -> bool {
-        left != right && !self.depends_on(left, right) && !self.depends_on(right, left)
-    }
-
-    /// Returns whether `package` transitively depends on `target`.
-    fn depends_on(&mut self, package: &str, target: &str) -> bool {
-        if !self.reachable.contains_key(package) {
-            let Some(reachable) = self.collect_reachable(package) else {
-                return true;
-            };
-            self.reachable.insert(package.to_owned(), reachable);
-        }
-
-        self.reachable
-            .get(package)
-            .is_none_or(|reachable| reachable.contains(target))
-    }
-
-    /// Collects the packages transitively reachable from `root`.
-    fn collect_reachable(&self, root: &str) -> Option<HashSet<String>> {
-        let mut reachable = HashSet::new();
-        let mut pending = vec![root];
-
-        while let Some(package) = pending.pop() {
-            if !reachable.insert(package.to_owned()) {
-                continue;
-            }
-            let dependencies = self.dependencies.get(package)?;
-            pending.extend(dependencies.iter().map(String::as_str));
-        }
-
-        reachable.remove(root);
-        Some(reachable)
-    }
-}
-
-/// Marks a target complete after reporting its fixes and remaining diagnostics.
 fn finish_unit(
-    unit: BuildUnit,
-    active_units: &mut IndexMap<BuildUnit, ActiveState>,
-    errors: &mut BuildUnitErrors,
-    seen: &mut HashSet<BuildUnit>,
+    unit_id: &UnitId,
+    active_units: &IndexMap<UnitId, ActiveState>,
+    errors: Option<&IndexSet<String>>,
 ) -> CargoResult<()> {
-    if seen
-        .iter()
-        .all(|build_unit| build_unit.package_id != unit.package_id)
-    {
-        shell::status("Checking", format_package_id(&unit.package_id)?)?;
-    }
-
-    if let Some(state) = active_units.get(&unit) {
+    trace!("finishing build unit `{unit_id:?}`");
+    if let Some(state) = active_units.get(unit_id) {
         for (name, file) in &state.snapshots {
             shell::fixed(name, file.fixes)?;
         }
     }
 
-    for error in errors.get(&unit).into_iter().flatten() {
+    for error in errors.into_iter().flatten() {
         shell::print_ansi_stderr(format!("{}\n\n", error.trim_end()).as_bytes())?;
     }
 
-    active_units.shift_remove(&unit);
-    errors.shift_remove(&unit);
-    seen.insert(unit);
     Ok(())
 }
 
@@ -759,12 +552,14 @@ fn to_check_output(output: std::process::Output) -> (Vec<CheckOutput>, Option<i3
 #[tracing::instrument(skip_all)]
 fn collect_diagnostics(
     messages: impl Iterator<Item = CheckOutput>,
-    seen: &HashSet<BuildUnit>,
+    finished: &BTreeSet<UnitId>,
     primary_packages: &PrimaryPackages,
+    active_units: &mut IndexMap<UnitId, ActiveState>,
+    max_iterations: usize,
 ) -> (BuildUnitErrors, BuildUnitSuggestions) {
     let only = HashSet::new();
-    let mut suggestions = IndexMap::new();
 
+    let mut suggestions = IndexMap::new();
     let mut errors = IndexMap::new();
 
     for message in messages {
@@ -774,22 +569,30 @@ fn collect_diagnostics(
         } = match message {
             CheckOutput::Message(m) => m,
             CheckOutput::Artifact(a) => {
-                if !seen.contains(&a.build_unit) && !a.fresh {
-                    suggestions
-                        .entry(a.build_unit.clone())
-                        .or_insert(IndexMap::new());
-                }
+                let unit_id = UnitId::from_message(&a.build_unit);
+                errors.entry(unit_id).or_insert_with(IndexSet::new);
                 continue;
             }
         };
 
-        let errors = errors
-            .entry(build_unit.clone())
-            .or_insert_with(IndexSet::new);
-
-        if seen.contains(&build_unit) {
-            trace!("rejecting build unit `{:?}` already seen", build_unit);
+        let unit_id = UnitId::from_message(&build_unit);
+        if finished.contains(&unit_id) {
+            trace!("rejecting build unit `{:?}` already finished", build_unit);
             continue;
+        }
+
+        if let Some(state) = active_units.get_mut(&unit_id) {
+            if state.iterations >= max_iterations {
+                trace!(
+                    "rejecting build unit `{:?}` exceeded max iteration count",
+                    build_unit
+                );
+                let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
+                if let Some(rendered) = diagnostic.rendered {
+                    errors.insert(rendered);
+                }
+                continue;
+            }
         }
 
         if !primary_packages.contains(&build_unit.package_id) {
@@ -797,24 +600,21 @@ fn collect_diagnostics(
                 "rejecting build unit `{:?}` not selected by the user",
                 build_unit
             );
+            let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
             if let Some(rendered) = diagnostic.rendered {
                 errors.insert(rendered);
             }
             continue;
         }
 
-        let unit_suggestions = suggestions
-            .entry(build_unit.clone())
-            .or_insert(IndexMap::new());
-
         let filter = if env::var("__CARGO_FIX_YOLO").is_ok() {
             rustfix::Filter::Everything
         } else {
             rustfix::Filter::MachineApplicableOnly
         };
-
         let Some(suggestion) = collect_suggestions(&diagnostic, &only, filter) else {
             trace!("rejecting as not a MachineApplicable diagnosis: {diagnostic:?}");
+            let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
             if let Some(rendered) = diagnostic.rendered {
                 errors.insert(rendered);
             }
@@ -829,6 +629,7 @@ fn collect_diagnostics(
 
         let Some(file_name) = file_names.next() else {
             trace!("rejecting as it has no solutions {:?}", suggestion);
+            let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
             if let Some(rendered) = diagnostic.rendered {
                 errors.insert(rendered);
             }
@@ -837,6 +638,7 @@ fn collect_diagnostics(
 
         if !file_names.all(|f| f == file_name) {
             trace!("rejecting as it changes multiple files: {:?}", suggestion);
+            let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
             if let Some(rendered) = diagnostic.rendered {
                 errors.insert(rendered);
             }
@@ -847,6 +649,7 @@ fn collect_diagnostics(
         // Do not write into registry cache. See rust-lang/cargo#9857.
         if let Ok(home) = env::var("CARGO_HOME") {
             if file_path.starts_with(home) {
+                let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
                 if let Some(rendered) = diagnostic.rendered {
                     errors.insert(rendered);
                 }
@@ -857,6 +660,7 @@ fn collect_diagnostics(
         if file_path.is_absolute() {
             if let Some(sysroot) = get_sysroot() {
                 if file_path.starts_with(sysroot) {
+                    let errors = errors.entry(unit_id).or_insert_with(IndexSet::new);
                     if let Some(rendered) = diagnostic.rendered {
                         errors.insert(rendered);
                     }
@@ -865,6 +669,9 @@ fn collect_diagnostics(
             }
         }
 
+        let unit_suggestions = suggestions
+            .entry(unit_id.clone())
+            .or_insert(IndexMap::new());
         unit_suggestions
             .entry(file_name.to_owned())
             .or_insert_with(IndexSet::new)
@@ -876,9 +683,8 @@ fn collect_diagnostics(
 
 #[tracing::instrument(skip_all)]
 fn fix_suggestions(
-    unit_suggestions: IndexMap<String, IndexSet<(Suggestion, Option<String>)>>,
+    unit_suggestions: &IndexMap<String, IndexSet<(Suggestion, Option<String>)>>,
     state: &mut ActiveState,
-    errors: &mut IndexSet<String>,
 ) -> CargoResult<bool> {
     let mut made_changes = false;
     for (file, suggestions) in unit_suggestions {
@@ -886,7 +692,6 @@ fn fix_suggestions(
             Ok(s) => s,
             Err(e) => {
                 warn!("failed to read `{}`: {}", file, e);
-                errors.extend(suggestions.iter().filter_map(|(_, e)| e.clone()));
                 continue;
             }
         };
@@ -894,16 +699,13 @@ fn fix_suggestions(
         let mut fixed = CodeFix::new(&source);
         let mut num_fixes = 0;
 
-        for (suggestion, rendered) in suggestions.iter().rev() {
+        for (suggestion, _rendered) in suggestions.iter().rev() {
             match fixed.apply(suggestion) {
                 Ok(()) => num_fixes += 1,
                 Err(rustfix::Error::AlreadyReplaced {
                     is_identical: true, ..
                 }) => {}
                 Err(e) => {
-                    if let Some(rendered) = rendered {
-                        errors.insert(rendered.to_owned());
-                    }
                     warn!("{e:?}");
                 }
             }
@@ -914,11 +716,235 @@ fn fix_suggestions(
                 fixes: 0,
                 original_source: source,
             });
-            paths::write(&file, new_source)?;
+            paths::write(file, new_source)?;
             made_changes = true;
             file_state.fixes += num_fixes;
         }
     }
 
     Ok(made_changes)
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+struct UnitId {
+    inner: std::sync::Arc<UnitIdInner>,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+struct UnitIdInner {
+    // HACK: this should also track
+    // - test-mode or not
+    // - platform
+    // - host vs target mode
+    package_id: String,
+    target_kind: TargetKind,
+}
+
+impl UnitId {
+    fn from_message(build_unit: &BuildUnit) -> Self {
+        // HACK: just collapse all libs to one kind since we can't distinguish them
+        let target_kind = build_unit
+            .target
+            .kind
+            .first()
+            .expect("build unit targets have at least one kind");
+        let target_kind = match target_kind {
+            TargetKind::Lib(_) => TargetKind::Lib(CrateType::Lib),
+            target_kind => target_kind.clone(),
+        };
+
+        Self {
+            inner: std::sync::Arc::new(UnitIdInner {
+                package_id: build_unit.package_id.clone(),
+                target_kind,
+            }),
+        }
+    }
+
+    fn from_metadata(
+        package: &cargo_metadata::Package,
+        target_kind: &cargo_metadata::TargetKind,
+    ) -> Self {
+        let target_kind = match target_kind {
+            cargo_metadata::TargetKind::Bin => TargetKind::Bin,
+            cargo_metadata::TargetKind::Test => TargetKind::Test,
+            cargo_metadata::TargetKind::Bench => TargetKind::Bench,
+            cargo_metadata::TargetKind::Example => TargetKind::Example,
+            cargo_metadata::TargetKind::CustomBuild => TargetKind::CustomBuild,
+            // HACK: just collapse all libs to one kind since we can't distinguish them
+            cargo_metadata::TargetKind::Lib
+            | cargo_metadata::TargetKind::RLib
+            | cargo_metadata::TargetKind::DyLib
+            | cargo_metadata::TargetKind::CDyLib
+            | cargo_metadata::TargetKind::StaticLib
+            | cargo_metadata::TargetKind::ProcMacro => TargetKind::Lib(CrateType::Lib),
+            target_kind => TargetKind::Lib(CrateType::Other(target_kind.to_string())),
+        };
+
+        Self {
+            inner: std::sync::Arc::new(UnitIdInner {
+                package_id: package.id.repr.clone(),
+                target_kind,
+            }),
+        }
+    }
+
+    fn package_id(&self) -> &str {
+        &self.inner.package_id
+    }
+
+    fn target_kind(&self) -> &TargetKind {
+        &self.inner.target_kind
+    }
+}
+
+#[derive(Debug)]
+struct UnitGraph {
+    dependencies: BTreeMap<UnitId, BTreeSet<UnitId>>,
+    finished: BTreeSet<UnitId>,
+}
+
+impl UnitGraph {
+    fn flat(metadata: &Metadata) -> Self {
+        let mut dependencies = BTreeMap::default();
+        for package in &metadata.packages {
+            for target in &package.targets {
+                for kind in &target.kind {
+                    let unit_id = UnitId::from_metadata(package, kind);
+                    dependencies.insert(unit_id, Default::default());
+                }
+            }
+        }
+
+        Self {
+            dependencies,
+            finished: Default::default(),
+        }
+    }
+
+    fn new(metadata: &Metadata) -> Self {
+        let mut dependencies = BTreeMap::default();
+        let mut path_to_lib_unit_ids = BTreeMap::default();
+        for package in &metadata.packages {
+            let mut build_script_unit_id = None;
+            let mut lib_unit_ids = BTreeSet::new();
+            let mut other_unit_ids = BTreeSet::new();
+            for target in &package.targets {
+                for kind in &target.kind {
+                    let unit_id = UnitId::from_metadata(package, kind);
+                    if matches!(unit_id.target_kind(), TargetKind::CustomBuild) {
+                        build_script_unit_id = Some(unit_id);
+                    } else if matches!(unit_id.target_kind(), TargetKind::Lib(_)) {
+                        lib_unit_ids.insert(unit_id);
+                    } else {
+                        other_unit_ids.insert(unit_id);
+                    }
+                }
+            }
+
+            for unit_id in other_unit_ids {
+                let deps = if !lib_unit_ids.is_empty() {
+                    lib_unit_ids.clone()
+                } else {
+                    build_script_unit_id.clone().into_iter().collect()
+                };
+                dependencies.insert(unit_id, deps);
+            }
+            if !lib_unit_ids.is_empty() {
+                let path_source = manifest_path_to_dep_path(&package.manifest_path);
+                path_to_lib_unit_ids.insert(path_source.to_owned(), lib_unit_ids.clone());
+                for unit_id in lib_unit_ids {
+                    let deps = build_script_unit_id.clone().into_iter().collect();
+                    dependencies.insert(unit_id, deps);
+                }
+            }
+            if let Some(unit_id) = build_script_unit_id {
+                dependencies.insert(unit_id, Default::default());
+            }
+        }
+
+        for package in &metadata.packages {
+            for dependency in &package.dependencies {
+                let Some(dep_path) = &dependency.path else {
+                    continue;
+                };
+                let Some(dep_unit_ids) = path_to_lib_unit_ids.get(dep_path) else {
+                    continue;
+                };
+                for target in &package.targets {
+                    for kind in &target.kind {
+                        let unit_id = UnitId::from_metadata(package, kind);
+                        let applies = match (&unit_id.target_kind(), &dependency.kind) {
+                            (TargetKind::CustomBuild, cargo_metadata::DependencyKind::Build) => {
+                                true
+                            }
+                            (TargetKind::Lib(_), cargo_metadata::DependencyKind::Normal) => true,
+                            (TargetKind::Lib(_), cargo_metadata::DependencyKind::Development) => {
+                                // HACK: should include for unit test variant except that would
+                                // cause cycles
+                                false
+                            }
+                            (TargetKind::Bin, cargo_metadata::DependencyKind::Normal) => true,
+                            (TargetKind::Bin, cargo_metadata::DependencyKind::Development) => {
+                                // HACK: for the unit test variant
+                                true
+                            }
+                            (TargetKind::Test, cargo_metadata::DependencyKind::Normal) => true,
+                            (TargetKind::Test, cargo_metadata::DependencyKind::Development) => true,
+                            (TargetKind::Bench, cargo_metadata::DependencyKind::Normal) => true,
+                            (TargetKind::Bench, cargo_metadata::DependencyKind::Development) => {
+                                true
+                            }
+                            (TargetKind::Example, cargo_metadata::DependencyKind::Normal) => true,
+                            (TargetKind::Example, cargo_metadata::DependencyKind::Development) => {
+                                true
+                            }
+                            _ => false,
+                        };
+                        if applies {
+                            dependencies
+                                .entry(unit_id)
+                                .or_default()
+                                .extend(dep_unit_ids.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            dependencies,
+            finished: Default::default(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.dependencies.is_empty()
+    }
+
+    fn take_ready(&mut self) -> BTreeSet<UnitId> {
+        self.dependencies
+            .extract_if(.., |_k, v| v.is_empty())
+            .map(|(k, _v)| k)
+            .collect()
+    }
+
+    fn mark_finished(&mut self, finished: BTreeSet<UnitId>) {
+        for dependencies in self.dependencies.values_mut() {
+            dependencies.retain(|id| !finished.contains(id));
+        }
+        self.finished.extend(finished);
+    }
+}
+
+fn manifest_path_to_dep_path(manifest_path: &camino::Utf8Path) -> &camino::Utf8Path {
+    if manifest_path.ends_with("Cargo.toml") {
+        manifest_path.parent().unwrap()
+    } else {
+        manifest_path
+    }
+}
+
+fn is_local(package_id: &str) -> bool {
+    package_id.starts_with("path+")
 }

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -209,7 +209,7 @@ fn fix(args: &FixitArgs, active_units: &mut IndexMap<BuildUnit, ActiveState>) ->
         }
 
         let (mut errors, mut suggestions) =
-            collect_errors(messages.into_iter(), &seen, &primary_packages);
+            collect_diagnostics(messages.into_iter(), &seen, &primary_packages);
 
         if iteration >= max_iterations {
             if active_units.is_empty() {
@@ -332,7 +332,7 @@ fn fix(args: &FixitArgs, active_units: &mut IndexMap<BuildUnit, ActiveState>) ->
                 }
 
                 let state = active_units.entry(build_unit.clone()).or_default();
-                let changed = fix_errors(unit_suggestions, state, build_unit_errors)?;
+                let changed = fix_suggestions(unit_suggestions, state, build_unit_errors)?;
                 if !changed && !was_active {
                     active_units.shift_remove(&build_unit);
                 }
@@ -757,7 +757,7 @@ fn to_check_output(output: std::process::Output) -> (Vec<CheckOutput>, Option<i3
 }
 
 #[tracing::instrument(skip_all)]
-fn collect_errors(
+fn collect_diagnostics(
     messages: impl Iterator<Item = CheckOutput>,
     seen: &HashSet<BuildUnit>,
     primary_packages: &PrimaryPackages,
@@ -875,7 +875,7 @@ fn collect_errors(
 }
 
 #[tracing::instrument(skip_all)]
-fn fix_errors(
+fn fix_suggestions(
     unit_suggestions: IndexMap<String, IndexSet<(Suggestion, Option<String>)>>,
     state: &mut ActiveState,
     errors: &mut IndexSet<String>,

--- a/src/ops/fixit.rs
+++ b/src/ops/fixit.rs
@@ -203,7 +203,7 @@ fn fix(
             anyhow::bail!("could not compile");
         }
 
-        let (mut errors, mut build_unit_map) =
+        let (mut errors, mut suggestions) =
             collect_errors(messages.into_iter(), &seen, &primary_packages);
 
         if iteration >= max_iterations {
@@ -212,10 +212,10 @@ fn fix(
             }
             let targets: Vec<_> = active_units.keys().cloned().collect();
             for target in targets {
-                if let Some(file_map) = build_unit_map.get(&target) {
+                if let Some(unit_suggestions) = suggestions.get(&target) {
                     let target_errors = errors.entry(target.clone()).or_default();
                     target_errors.extend(
-                        file_map
+                        unit_suggestions
                             .values()
                             .flatten()
                             .filter_map(|(_, diagnostic)| diagnostic.clone()),
@@ -231,11 +231,11 @@ fn fix(
         if !active_units.is_empty()
             && active_units
                 .keys()
-                .all(|target| build_unit_map.get(target).is_none_or(IndexMap::is_empty))
+                .all(|target| suggestions.get(target).is_none_or(IndexMap::is_empty))
         {
             let targets: Vec<_> = active_units.keys().cloned().collect();
             for target in targets {
-                build_unit_map.shift_remove(&target);
+                suggestions.shift_remove(&target);
                 finish_unit(target, active_units, &mut errors, &mut seen)?;
             }
             debug_assert!(active_units.is_empty());
@@ -249,7 +249,7 @@ fn fix(
         // Once a batch is active, recheck and finish it before considering additional units.
         let continuing_batch = !active_units.is_empty();
 
-        for (build_unit, file_map) in build_unit_map {
+        for (build_unit, unit_suggestions) in suggestions {
             if seen.contains(&build_unit) {
                 continue;
             }
@@ -258,7 +258,7 @@ fn fix(
                 .entry(build_unit.clone())
                 .or_insert_with(IndexSet::new);
 
-            if active_units.is_empty() && file_map.is_empty() {
+            if active_units.is_empty() && unit_suggestions.is_empty() {
                 if finalized_targets && build_unit_errors.is_empty() {
                     continue;
                 }
@@ -271,7 +271,7 @@ fn fix(
                 errors.shift_remove(&build_unit);
 
                 seen.insert(build_unit);
-            } else if !file_map.is_empty() {
+            } else if !unit_suggestions.is_empty() {
                 let was_active = active_units.contains_key(&build_unit);
                 if continuing_batch && !was_active {
                     continue;
@@ -307,7 +307,7 @@ fn fix(
                     }
                 }
 
-                let handles = file_map
+                let handles = unit_suggestions
                     .keys()
                     .map(same_file::Handle::from_path)
                     .collect::<Result<Vec<_>, _>>()
@@ -327,7 +327,7 @@ fn fix(
                 }
 
                 let target_files = active_units.entry(build_unit.clone()).or_default();
-                let changed = fix_errors(target_files, file_map, build_unit_errors)?;
+                let changed = fix_errors(target_files, unit_suggestions, build_unit_errors)?;
                 if !changed && !was_active {
                     active_units.shift_remove(&build_unit);
                 }
@@ -758,7 +758,7 @@ fn collect_errors(
     primary_packages: &PrimaryPackages,
 ) -> (BuildUnitErrors, BuildUnitSuggestions) {
     let only = HashSet::new();
-    let mut build_unit_map = IndexMap::new();
+    let mut suggestions = IndexMap::new();
 
     let mut errors = IndexMap::new();
 
@@ -770,7 +770,7 @@ fn collect_errors(
             CheckOutput::Message(m) => m,
             CheckOutput::Artifact(a) => {
                 if !seen.contains(&a.build_unit) && !a.fresh {
-                    build_unit_map
+                    suggestions
                         .entry(a.build_unit.clone())
                         .or_insert(IndexMap::new());
                 }
@@ -798,7 +798,7 @@ fn collect_errors(
             continue;
         }
 
-        let file_map = build_unit_map
+        let unit_suggestions = suggestions
             .entry(build_unit.clone())
             .or_insert(IndexMap::new());
 
@@ -860,23 +860,23 @@ fn collect_errors(
             }
         }
 
-        file_map
+        unit_suggestions
             .entry(file_name.to_owned())
             .or_insert_with(IndexSet::new)
             .insert((suggestion, diagnostic.rendered));
     }
 
-    (errors, build_unit_map)
+    (errors, suggestions)
 }
 
 #[tracing::instrument(skip_all)]
 fn fix_errors(
     files: &mut IndexMap<String, File>,
-    file_map: IndexMap<String, IndexSet<(Suggestion, Option<String>)>>,
+    unit_suggestions: IndexMap<String, IndexSet<(Suggestion, Option<String>)>>,
     errors: &mut IndexSet<String>,
 ) -> CargoResult<bool> {
     let mut made_changes = false;
-    for (file, suggestions) in file_map {
+    for (file, suggestions) in unit_suggestions {
         let source = match paths::read(file.as_ref()) {
             Ok(s) => s,
             Err(e) => {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -205,10 +205,10 @@ fn select_path_dep() {
     p.cargo_("fix --allow-no-vcs -p foo -p bar")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
-[CHECKING] foo v0.1.0
-[FIXED] src/lib.rs (1 fix)
 [CHECKING] bar v0.1.0
 [FIXED] bar/src/lib.rs (1 fix)
+[CHECKING] foo v0.1.0
+[FIXED] src/lib.rs (1 fix)
 
 "#]])
         .run();
@@ -256,7 +256,6 @@ fn select_implicit_ignores_path_dep() {
     p.cargo_("fix --allow-no-vcs")
         .cwd("foo")
         .with_stderr_data(str![[r#"
-[CHECKING] bar v0.1.0
 [WARNING] variable does not need to be mutable
  --> [ROOT]/foo/bar/src/lib.rs:3:25
   |
@@ -267,6 +266,7 @@ fn select_implicit_ignores_path_dep() {
   |
   = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
+[CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0
 [FIXED] src/lib.rs (1 fix)
 
@@ -287,9 +287,6 @@ resolver = '2'
     p.cargo_("fix --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/src/main.rs (1 fix)
-[FIXED] a/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
 [WARNING] variable does not need to be mutable
  --> b/build.rs:1:16
@@ -311,6 +308,9 @@ resolver = '2'
   |
   = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] a/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -328,9 +328,6 @@ resolver = '2'
     p.cargo_("fix --package a --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/src/main.rs (1 fix)
-[FIXED] a/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
 [WARNING] variable does not need to be mutable
  --> b/build.rs:1:16
@@ -352,6 +349,9 @@ resolver = '2'
   |
   = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] a/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -369,9 +369,6 @@ resolver = '2'
     p.cargo_("fix --workspace --exclude b* --exclude c* --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/src/main.rs (1 fix)
-[FIXED] a/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
 [WARNING] variable does not need to be mutable
  --> b/build.rs:1:16
@@ -393,6 +390,9 @@ resolver = '2'
   |
   = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] a/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -410,14 +410,14 @@ resolver = '2'
     p.cargo_("fix --workspace --lib --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/build.rs (1 fix)
-[CHECKING] c v0.1.0
-[FIXED] c/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
-[FIXED] c/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
+[CHECKING] c v0.1.0
+[FIXED] a/build.rs (1 fix)
 [FIXED] b/build.rs (1 fix)
+[FIXED] c/build.rs (1 fix)
 [FIXED] b/src/lib.rs (1 fix)
+[FIXED] c/src/lib.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
 
 "#]])
         .run();
@@ -435,17 +435,17 @@ resolver = '2'
     p.cargo_("fix --workspace --bins --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/src/main.rs (1 fix)
-[CHECKING] c v0.1.0
-[FIXED] c/src/main.rs (1 fix)
-[FIXED] a/build.rs (1 fix)
-[FIXED] c/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
-[FIXED] c/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
-[FIXED] b/src/main.rs (1 fix)
+[CHECKING] c v0.1.0
+[FIXED] a/build.rs (1 fix)
 [FIXED] b/build.rs (1 fix)
+[FIXED] c/build.rs (1 fix)
 [FIXED] b/src/lib.rs (1 fix)
+[FIXED] c/src/lib.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] b/src/main.rs (1 fix)
+[FIXED] c/src/main.rs (1 fix)
+[FIXED] a/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -463,12 +463,12 @@ resolver = '2'
     p.cargo_("fix --workspace --bin a --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/src/main.rs (1 fix)
-[FIXED] a/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
+[FIXED] a/build.rs (1 fix)
 [FIXED] b/build.rs (1 fix)
 [FIXED] b/src/lib.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] a/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -486,8 +486,6 @@ resolver = '2'
     p.cargo_("fix -p a --lib --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
 [WARNING] variable does not need to be mutable
  --> b/build.rs:1:16
@@ -509,6 +507,8 @@ resolver = '2'
   |
   = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
 
 "#]])
         .run();
@@ -526,9 +526,6 @@ resolver = '2'
     p.cargo_("fix -p a --bins --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/src/main.rs (1 fix)
-[FIXED] a/build.rs (1 fix)
-[FIXED] a/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
 [WARNING] variable does not need to be mutable
  --> b/build.rs:1:16
@@ -550,6 +547,9 @@ resolver = '2'
   |
   = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] a/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -595,9 +595,9 @@ resolver = '2'
     p.cargo_("fix -p a --allow-no-vcs")
         .with_stderr_data(str![[r#"
 [CHECKING] a v0.1.0
-[FIXED] a/src/main.rs (1 fix)
 [FIXED] a/build.rs (1 fix)
 [FIXED] a/src/lib.rs (1 fix)
+[FIXED] a/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -896,6 +896,7 @@ fn upgrade_extern_crate() {
     p.cargo_("fix --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stderr_data(str![[r#"
+[CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0
 [FIXED] src/lib.rs (1 fix)
 
@@ -1879,8 +1880,8 @@ fn doesnt_rebuild_dependencies() {
         .with_stderr_data(str![[r#"
      Checked foo v0.1.0 - foo (lib)
      Checked bar v0.1.0 - bar (lib)
-[CHECKING] foo v0.1.0
 [CHECKING] bar v0.1.0
+[CHECKING] foo v0.1.0
 
 "#]])
         .run();
@@ -1889,6 +1890,8 @@ fn doesnt_rebuild_dependencies() {
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.1.0
 
 "#]])
         .run();
@@ -2343,6 +2346,7 @@ fn fix_shared_cross_workspace() {
         .with_stderr_data(
             str![[r#"
 [CHECKING] [..] v0.1.0
+[CHECKING] [..] v0.1.0
 [FIXED] [..]foo/src/shared.rs (2 fixes)
 
 "#]]
@@ -2427,6 +2431,8 @@ fn abnormal_exit() {
         )
         // "signal: 6, SIGABRT: process abort signal" on some platforms
         .with_stderr_data(str![[r#"
+[CHECKING] pm v0.1.0
+[CHECKING] foo v0.1.0
 [NOTE] reverting `src/lib.rs` to its original state
 [WARNING] failed to automatically apply fixes suggested by rustc
 
@@ -2729,6 +2735,7 @@ fn fix_in_dependency() {
     p.cargo_("fix --lib --allow-no-vcs")
         .env("RUSTC", &rustc_bin)
         .with_stderr_data(str![[r#"
+[CHECKING] bar v1.0.0
 [CHECKING] foo v0.1.0
 [WARNING] unused variable: `abc`
  --> [ROOT]/home/.cargo/registry/src/-[HASH]/bar-1.0.0/src/lib.rs:5:29
@@ -2738,7 +2745,6 @@ fn fix_in_dependency() {
   |
   = [NOTE] `#[warn(unused_variables)]` on by default
 
-[CHECKING] bar v1.0.0
 
 "#]])
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -163,7 +163,7 @@ fn fix_broken_if_requested() {
 }
 
 #[cargo_test]
-fn fix_path_deps() {
+fn select_path_dep() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -203,23 +203,19 @@ fn fix_path_deps() {
         .build();
 
     p.cargo_("fix --allow-no-vcs -p foo -p bar")
-        .env("__CARGO_FIX_YOLO", "1")
         .with_stdout_data("")
-        .with_stderr_data(
-            str![[r#"
-[CHECKING] bar v0.1.0
-[FIXED] bar/src/lib.rs (1 fix)
+        .with_stderr_data(str![[r#"
 [CHECKING] foo v0.1.0
 [FIXED] src/lib.rs (1 fix)
+[CHECKING] bar v0.1.0
+[FIXED] bar/src/lib.rs (1 fix)
 
-"#]]
-            .unordered(),
-        )
+"#]])
         .run();
 }
 
 #[cargo_test]
-fn do_not_fix_non_relevant_deps() {
+fn select_implicit_ignores_path_dep() {
     let p = project()
         .no_manifest()
         .file(
@@ -236,7 +232,15 @@ fn do_not_fix_non_relevant_deps() {
                 [workspace]
             "#,
         )
-        .file("foo/src/lib.rs", "")
+        .file(
+            "foo/src/lib.rs",
+            r#"
+                pub fn foo() -> u32 {
+                    let mut x = 3;
+                    x
+                }
+            "#,
+        )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
@@ -250,44 +254,353 @@ fn do_not_fix_non_relevant_deps() {
         .build();
 
     p.cargo_("fix --allow-no-vcs")
-        .env("__CARGO_FIX_YOLO", "1")
         .cwd("foo")
-        .run();
+        .with_stderr_data(str![[r#"
+[CHECKING] bar v0.1.0
+[WARNING] variable does not need to be mutable
+ --> [ROOT]/foo/bar/src/lib.rs:3:25
+  |
+3 |                     let mut x = 3;
+  |                         ----^
+  |                         |
+  |                         [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
-    assert!(p.read_file("bar/src/lib.rs").contains("mut"));
+[CHECKING] foo v0.1.0
+[FIXED] src/lib.rs (1 fix)
+
+"#]])
+        .run();
 }
 
 #[cargo_test]
-fn does_not_fix_dependency_of_default_workspace_member() {
+fn select_implicit_ignores_workspace_member() {
     let p = package_selection_project(
-        "[workspace]\nmembers = ['a', 'b']\ndefault-members = ['a']\nresolver = '2'\n",
+        "[workspace]
+members = ['a', 'b', 'c']
+default-members = ['a']
+resolver = '2'
+",
     );
 
-    p.cargo_("fix --allow-no-vcs").run();
+    p.cargo_("fix --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/main.rs (1 fix)
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[WARNING] variable does not need to be mutable
+ --> b/build.rs:1:16
+  |
+1 | fn main(){ let mut a = 1; let _ = a; }
+  |                ----^
+  |                |
+  |                [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
-    assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
-    assert!(p.read_file("b/src/lib.rs").contains("let mut value"));
-}
+[WARNING] variable does not need to be mutable
+ --> b/src/lib.rs:1:31
+  |
+1 | pub fn value() -> usize { let mut value = 1; value }
+  |                               ----^^^^^
+  |                               |
+  |                               [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
-#[cargo_test]
-fn does_not_fix_dependency_of_selected_workspace_package() {
-    let p = package_selection_project("[workspace]\nmembers = ['a', 'b']\nresolver = '2'\n");
 
-    p.cargo_("fix --package a --allow-no-vcs").run();
-
-    assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
-    assert!(p.read_file("b/src/lib.rs").contains("let mut value"));
-}
-
-#[cargo_test]
-fn does_not_fix_excluded_workspace_dependency() {
-    let p = package_selection_project("[workspace]\nmembers = ['a', 'b']\nresolver = '2'\n");
-
-    p.cargo_("fix --workspace --exclude b* --allow-no-vcs")
+"#]])
         .run();
+}
 
-    assert!(!p.read_file("a/src/lib.rs").contains("let mut value"));
-    assert!(p.read_file("b/src/lib.rs").contains("let mut value"));
+#[cargo_test]
+fn select_package_ignores_workspace_member() {
+    let p = package_selection_project(
+        "[workspace]
+members = ['a', 'b', 'c']
+resolver = '2'
+",
+    );
+
+    p.cargo_("fix --package a --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/main.rs (1 fix)
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[WARNING] variable does not need to be mutable
+ --> b/build.rs:1:16
+  |
+1 | fn main(){ let mut a = 1; let _ = a; }
+  |                ----^
+  |                |
+  |                [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+[WARNING] variable does not need to be mutable
+ --> b/src/lib.rs:1:31
+  |
+1 | pub fn value() -> usize { let mut value = 1; value }
+  |                               ----^^^^^
+  |                               |
+  |                               [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn select_exclude_ignores_workspace_member() {
+    let p = package_selection_project(
+        "[workspace]
+members = ['a', 'b', 'c']
+resolver = '2'
+",
+    );
+
+    p.cargo_("fix --workspace --exclude b* --exclude c* --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/main.rs (1 fix)
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[WARNING] variable does not need to be mutable
+ --> b/build.rs:1:16
+  |
+1 | fn main(){ let mut a = 1; let _ = a; }
+  |                ----^
+  |                |
+  |                [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+[WARNING] variable does not need to be mutable
+ --> b/src/lib.rs:1:31
+  |
+1 | pub fn value() -> usize { let mut value = 1; value }
+  |                               ----^^^^^
+  |                               |
+  |                               [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn select_workspace_lib() {
+    let p = package_selection_project(
+        "[workspace]
+members = ['a', 'b', 'c']
+resolver = '2'
+",
+    );
+
+    p.cargo_("fix --workspace --lib --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/build.rs (1 fix)
+[CHECKING] c v0.1.0
+[FIXED] c/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] c/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[FIXED] b/build.rs (1 fix)
+[FIXED] b/src/lib.rs (1 fix)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn select_workspace_bins() {
+    let p = package_selection_project(
+        "[workspace]
+members = ['a', 'b', 'c']
+resolver = '2'
+",
+    );
+
+    p.cargo_("fix --workspace --bins --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/main.rs (1 fix)
+[CHECKING] c v0.1.0
+[FIXED] c/src/main.rs (1 fix)
+[FIXED] a/build.rs (1 fix)
+[FIXED] c/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[FIXED] c/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[FIXED] b/src/main.rs (1 fix)
+[FIXED] b/build.rs (1 fix)
+[FIXED] b/src/lib.rs (1 fix)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn select_workspace_bin() {
+    let p = package_selection_project(
+        "[workspace]
+members = ['a', 'b', 'c']
+resolver = '2'
+",
+    );
+
+    p.cargo_("fix --workspace --bin a --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/main.rs (1 fix)
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[FIXED] b/build.rs (1 fix)
+[FIXED] b/src/lib.rs (1 fix)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn select_package_lib() {
+    let p = package_selection_project(
+        "[workspace]
+members = ['a', 'b', 'c']
+resolver = '2'
+",
+    );
+
+    p.cargo_("fix -p a --lib --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[WARNING] variable does not need to be mutable
+ --> b/build.rs:1:16
+  |
+1 | fn main(){ let mut a = 1; let _ = a; }
+  |                ----^
+  |                |
+  |                [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+[WARNING] variable does not need to be mutable
+ --> b/src/lib.rs:1:31
+  |
+1 | pub fn value() -> usize { let mut value = 1; value }
+  |                               ----^^^^^
+  |                               |
+  |                               [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn select_package_bins() {
+    let p = package_selection_project(
+        "[workspace]
+members = ['a', 'b', 'c']
+resolver = '2'
+",
+    );
+
+    p.cargo_("fix -p a --bins --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/main.rs (1 fix)
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[WARNING] variable does not need to be mutable
+ --> b/build.rs:1:16
+  |
+1 | fn main(){ let mut a = 1; let _ = a; }
+  |                ----^
+  |                |
+  |                [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+[WARNING] variable does not need to be mutable
+ --> b/src/lib.rs:1:31
+  |
+1 | pub fn value() -> usize { let mut value = 1; value }
+  |                               ----^^^^^
+  |                               |
+  |                               [HELP] remove this `mut`
+  |
+  = [NOTE] `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
+
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn select_without_feature() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            "[workspace]
+members = ['a', 'b']
+resolver = '2'
+",
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                b = { path = '../b', optional = true }
+            "#,
+        )
+        .file("a/build.rs", "fn main(){ let mut a = 1; let _ = a; }")
+        .file("a/src/main.rs", "fn main(){ let mut a = 1; let _ = a; }")
+        .file(
+            "a/src/lib.rs",
+            "pub fn value() -> usize { let mut value = 1; value }\n",
+        )
+        .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
+        .file("b/build.rs", "fn main(){ let mut a = 1; let _ = a; }")
+        .file(
+            "b/src/lib.rs",
+            "pub fn value() -> usize { let mut value = 1; value }\n",
+        )
+        .file("b/src/main.rs", "fn main(){ let mut a = 1; let _ = a; }")
+        .build();
+
+    p.cargo_("fix -p a --allow-no-vcs")
+        .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[FIXED] a/src/main.rs (1 fix)
+[FIXED] a/build.rs (1 fix)
+[FIXED] a/src/lib.rs (1 fix)
+
+"#]])
+        .run();
 }
 
 fn package_selection_project(workspace_manifest: &str) -> Project {
@@ -305,15 +618,26 @@ fn package_selection_project(workspace_manifest: &str) -> Project {
                 b = { path = '../b' }
             "#,
         )
+        .file("a/build.rs", "fn main(){ let mut a = 1; let _ = a; }")
+        .file("a/src/main.rs", "fn main(){ let mut a = 1; let _ = a; }")
         .file(
             "a/src/lib.rs",
             "pub fn value() -> usize { let mut value = b::value(); value }\n",
         )
         .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
+        .file("b/build.rs", "fn main(){ let mut a = 1; let _ = a; }")
         .file(
             "b/src/lib.rs",
             "pub fn value() -> usize { let mut value = 1; value }\n",
         )
+        .file("b/src/main.rs", "fn main(){ let mut a = 1; let _ = a; }")
+        .file("c/Cargo.toml", &basic_manifest("c", "0.1.0"))
+        .file("c/build.rs", "fn main(){ let mut a = 1; let _ = a; }")
+        .file(
+            "c/src/lib.rs",
+            "pub fn value() -> usize { let mut value = 1; value }\n",
+        )
+        .file("c/src/main.rs", "fn main(){ let mut a = 1; let _ = a; }")
         .build()
 }
 

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1873,17 +1873,19 @@ fn doesnt_rebuild_dependencies() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo_("fix --allow-no-vcs -p foo")
+    p.cargo_("fix --allow-no-vcs -p foo --verbose")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"
+     Checked foo v0.1.0 - foo (lib)
+     Checked bar v0.1.0 - bar (lib)
 [CHECKING] foo v0.1.0
 [CHECKING] bar v0.1.0
 
 "#]])
         .run();
 
-    p.cargo_("fix --allow-no-vcs -p foo")
+    p.cargo_("fix --allow-no-vcs -p foo --verbose")
         .env("__CARGO_FIX_YOLO", "1")
         .with_stdout_data("")
         .with_stderr_data(str![[r#"

--- a/tests/testsuite/fix_n_times.rs
+++ b/tests/testsuite/fix_n_times.rs
@@ -390,6 +390,7 @@ fn fix_verification_failed() {
         &[Step::OneFix, Step::Error],
         |_execs| {},
         str![[r#"
+[CHECKING] foo v0.0.1
 [NOTE] reverting `src/lib.rs` to its original state
 [WARNING] failed to automatically apply fixes suggested by rustc
 
@@ -430,6 +431,7 @@ fn fix_verification_failed_clippy() {
             execs.env("RUSTC_WORKSPACE_WRAPPER", wrapped_clippy_driver());
         },
         str![[r#"
+[CHECKING] foo v0.0.1
 [NOTE] reverting `src/lib.rs` to its original state
 [WARNING] failed to automatically apply fixes suggested by rustc
 

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -398,6 +398,36 @@ path = \"src/main.rs\"
 }
 
 #[cargo_test]
+fn fix_order_multiple_lib_crate_types() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"{}
+[lib]
+crate-type = ["rlib", "cdylib"]
+"#,
+                basic_manifest("foo", "0.1.0")
+            ),
+        )
+        .file(
+            "src/lib.rs",
+            "pub fn foo() { let mut value = 1; let _ = value; }",
+        )
+        .build();
+
+    p.cargo_("fixit --allow-no-vcs --verbose")
+        .with_stderr_data(str![[r#"
+     Checked foo v0.1.0 - foo (lib)
+     Checked foo v0.1.0 - foo (lib)
+[CHECKING] foo v0.1.0
+[FIXED] src/lib.rs (1 fix)
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
 fn fix_order_host_target_dependency() {
     let p = project()
         .file(
@@ -493,20 +523,72 @@ fn foo() {
 }
 ",
         )
+        .file(
+            "tests/test_a.rs",
+            "
+fn _a(){ let mut a = 1; let _ = a; }
+
+#[test]
+fn foo() {
+    let mut a = 1;
+    let _ = a;
+}
+",
+        )
+        .file(
+            "tests/test_b.rs",
+            "
+fn _a(){ let mut a = 1; let _ = a; }
+
+#[test]
+fn foo() {
+    let mut a = 1;
+    let _ = a;
+}
+",
+        )
+        .file(
+            "examples/examp_a.rs",
+            "
+fn main(){ let mut a = 1; let _ = a; }
+",
+        )
+        .file(
+            "examples/examp_b.rs",
+            "
+fn main(){ let mut a = 1; let _ = a; }
+",
+        )
         .build();
 
     p.cargo_("fixit --allow-no-vcs --all-targets --verbose")
         .with_stderr_data(str![[r#"
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - app (bin)
+     Checked foo v0.1.0 - test_a (test)
+     Checked foo v0.1.0 - test_b (test)
+     Checked foo v0.1.0 - examp_a (example)
+     Checked foo v0.1.0 - examp_b (example)
      Checked foo v0.1.0 - foo (lib)
      Checked foo v0.1.0 - foo (lib)
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - app (bin)
 [CHECKING] foo v0.1.0
 [FIXED] src/main.rs (2 fixes)
+     Checked foo v0.1.0 - test_a (test)
+[FIXED] tests/test_a.rs (2 fixes)
+     Checked foo v0.1.0 - test_b (test)
+[FIXED] tests/test_b.rs (2 fixes)
+     Checked foo v0.1.0 - examp_a (example)
+[FIXED] examples/examp_a.rs (1 fix)
+     Checked foo v0.1.0 - examp_b (example)
+[FIXED] examples/examp_b.rs (1 fix)
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - app (bin)
+     Checked foo v0.1.0 - test_a (test)
+     Checked foo v0.1.0 - test_b (test)
+     Checked foo v0.1.0 - examp_a (example)
+     Checked foo v0.1.0 - examp_b (example)
      Checked foo v0.1.0 - foo (lib)
      Checked foo v0.1.0 - foo (lib)
 [FIXED] src/lib.rs (2 fixes)
@@ -774,6 +856,59 @@ a = {{ path = '../a' }}
 
 "#]])
         .run();
+}
+
+#[cargo_test]
+fn crate_fixed_on_two_targets() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"[workspace]
+members = ["app", "shared"]
+resolver = "2"
+"#,
+        )
+        .file(
+            "app/Cargo.toml",
+            &format!(
+                "{}
+[dependencies]
+shared = {{ path = '../shared' }}
+
+[build-dependencies]
+shared = {{ path = '../shared' }}
+",
+                basic_manifest("app", "0.1.0")
+            ),
+        )
+        .file("app/build.rs", "fn main() { shared::shared(); }\n")
+        .file("app/src/lib.rs", "pub fn app() { shared::shared(); }\n")
+        .file("shared/Cargo.toml", &basic_manifest("shared", "0.1.0"))
+        .file(
+            "shared/src/lib.rs",
+            "pub fn shared() { let mut value = 1; let _ = value; }\n",
+        )
+        .build();
+
+    p.cargo_("fixit --workspace --target host-tuple --allow-no-vcs --verbose")
+        .with_stderr_data(str![[r#"
+     Checked app v0.1.0 - build-script-build (custom-build)
+     Checked app v0.1.0 - app (lib)
+     Checked shared v0.1.0 - shared (lib)
+     Checked shared v0.1.0 - shared (lib)
+[CHECKING] app v0.1.0
+     Checked app v0.1.0 - build-script-build (custom-build)
+     Checked app v0.1.0 - app (lib)
+     Checked shared v0.1.0 - shared (lib)
+     Checked shared v0.1.0 - shared (lib)
+[CHECKING] shared v0.1.0
+[FIXED] shared/src/lib.rs (1 fix)
+
+"#]])
+        .run();
+
+    assert!(!p.read_file("shared/src/lib.rs").contains("let mut value"));
+    p.cargo_("check --workspace --target host-tuple").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -251,12 +251,12 @@ fn metadata_error() {
     p.cargo_("fixit --allow-no-vcs")
         .with_status(101)
         .with_stderr_data(str![[r#"
-[ERROR] unquoted keys cannot be empty, expected letters, numbers, `-`, `_`
+[ERROR] failed to run `cargo metadata`: `cargo metadata` exited with an [ERROR] [ERROR] unquoted keys cannot be empty, expected letters, numbers, `-`, `_`
  --> Cargo.toml:1:2
   |
 1 | [
   |  ^
-[ERROR] could not compile
+
 
 "#]])
         .run();

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -234,7 +234,7 @@ fn print_errors_after_fixed() {
 }
 
 #[cargo_test]
-fn non_json_error() {
+fn metadata_error() {
     let p = project()
         .file("Cargo.toml", "[")
         .file(
@@ -256,6 +256,30 @@ fn non_json_error() {
   |
 1 | [
   |  ^
+[ERROR] could not compile
+
+"#]])
+        .run();
+}
+
+#[cargo_test]
+fn non_json_error() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+            pub fn a() {
+                let mut b = 10;
+                let _ = b;
+            }
+            "#,
+        )
+        .build();
+
+    p.cargo_("fixit --allow-no-vcs --bin foo")
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no bin target named `foo` in default-run packages
 [ERROR] could not compile
 
 "#]])

--- a/tests/testsuite/fixit.rs
+++ b/tests/testsuite/fixit.rs
@@ -122,7 +122,10 @@ fn reuse_checks_cache() {
     p.cargo_("check").run();
 
     p.cargo_("fixit --allow-no-vcs --verbose")
-        .with_stderr_data(str![])
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.1.0
+
+"#]])
         .run();
 }
 
@@ -208,20 +211,20 @@ fn print_errors_after_fixed() {
     p.cargo_("fixit --allow-no-vcs")
         .with_status(0)
         .with_stderr_data(str![[r#"
-[CHECKING] a v0.1.0
-[FIXED] a/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+[FIXED] b/src/lib.rs (1 fix)
 [WARNING] function `bar` is never used
- --> a/src/lib.rs:1:5
+ --> b/src/lib.rs:1:5
   |
 1 |  fn bar() {}
   |     ^^^
   |
   = [NOTE] `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
-[CHECKING] b v0.1.0
-[FIXED] b/src/lib.rs (1 fix)
+[CHECKING] a v0.1.0
+[FIXED] a/src/lib.rs (1 fix)
 [WARNING] function `bar` is never used
- --> b/src/lib.rs:1:5
+ --> a/src/lib.rs:1:5
   |
 1 |  fn bar() {}
   |     ^^^
@@ -308,6 +311,7 @@ pub fn lib() { let mut value = 1; let _ = value; }
     p.cargo_("fixit --allow-no-vcs")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[CHECKING] foo v0.1.0
 [ERROR] failed to write `src/lib.rs`: Permission denied (os error 13)
 
 "#]])
@@ -347,6 +351,8 @@ resolver = "2"
     p.cargo_("fixit --workspace --allow-no-vcs")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[CHECKING] a v0.1.0
+[CHECKING] b v0.1.0
 [ERROR] failed to write `b/src/lib.rs`: Permission denied (os error 13)
 
 "#]])
@@ -381,10 +387,7 @@ path = \"src/main.rs\"
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - build-script-build (custom-build)
      Checked foo v0.1.0 - foo (lib)
-     Checked foo v0.1.0 - app (bin)
-     Checked foo v0.1.0 - foo (lib)
 [CHECKING] foo v0.1.0
-[FIXED] src/main.rs (1 fix)
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - build-script-build (custom-build)
      Checked foo v0.1.0 - foo (lib)
@@ -392,6 +395,9 @@ path = \"src/main.rs\"
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - foo (lib)
 [FIXED] src/lib.rs (1 fix)
+     Checked foo v0.1.0 - app (bin)
+     Checked foo v0.1.0 - foo (lib)
+[FIXED] src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -419,8 +425,8 @@ crate-type = ["rlib", "cdylib"]
     p.cargo_("fixit --allow-no-vcs --verbose")
         .with_stderr_data(str![[r#"
      Checked foo v0.1.0 - foo (lib)
-     Checked foo v0.1.0 - foo (lib)
 [CHECKING] foo v0.1.0
+     Checked foo v0.1.0 - foo (lib)
 [FIXED] src/lib.rs (1 fix)
 
 "#]])
@@ -468,18 +474,18 @@ dep = {{ path = '../dep' }}
      Checked app v0.1.0 - build-script-build (custom-build)
      Checked dep v0.1.0 - dep (lib)
      Checked dep v0.1.0 - dep (lib)
+[CHECKING] dep v0.1.0
      Checked app v0.1.0 - app (bin)
+     Checked app v0.1.0 - build-script-build (custom-build)
+     Checked dep v0.1.0 - dep (lib)
+     Checked dep v0.1.0 - dep (lib)
+[FIXED] dep/src/lib.rs (1 fix)
 [CHECKING] app v0.1.0
-[FIXED] app/src/main.rs (1 fix)
      Checked app v0.1.0 - app (bin)
      Checked app v0.1.0 - build-script-build (custom-build)
 [FIXED] app/build.rs (1 fix)
      Checked app v0.1.0 - app (bin)
-     Checked app v0.1.0 - build-script-build (custom-build)
-     Checked dep v0.1.0 - dep (lib)
-     Checked dep v0.1.0 - dep (lib)
-[CHECKING] dep v0.1.0
-[FIXED] dep/src/lib.rs (1 fix)
+[FIXED] app/src/main.rs (1 fix)
 
 "#]])
         .run();
@@ -571,18 +577,7 @@ fn main(){ let mut a = 1; let _ = a; }
      Checked foo v0.1.0 - examp_b (example)
      Checked foo v0.1.0 - foo (lib)
      Checked foo v0.1.0 - foo (lib)
-     Checked foo v0.1.0 - app (bin)
-     Checked foo v0.1.0 - app (bin)
 [CHECKING] foo v0.1.0
-[FIXED] src/main.rs (2 fixes)
-     Checked foo v0.1.0 - test_a (test)
-[FIXED] tests/test_a.rs (2 fixes)
-     Checked foo v0.1.0 - test_b (test)
-[FIXED] tests/test_b.rs (2 fixes)
-     Checked foo v0.1.0 - examp_a (example)
-[FIXED] examples/examp_a.rs (1 fix)
-     Checked foo v0.1.0 - examp_b (example)
-[FIXED] examples/examp_b.rs (1 fix)
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - app (bin)
      Checked foo v0.1.0 - test_a (test)
@@ -592,6 +587,17 @@ fn main(){ let mut a = 1; let _ = a; }
      Checked foo v0.1.0 - foo (lib)
      Checked foo v0.1.0 - foo (lib)
 [FIXED] src/lib.rs (2 fixes)
+     Checked foo v0.1.0 - app (bin)
+     Checked foo v0.1.0 - app (bin)
+     Checked foo v0.1.0 - test_a (test)
+     Checked foo v0.1.0 - test_b (test)
+     Checked foo v0.1.0 - examp_a (example)
+     Checked foo v0.1.0 - examp_b (example)
+[FIXED] src/main.rs (2 fixes)
+[FIXED] tests/test_a.rs (2 fixes)
+[FIXED] tests/test_b.rs (2 fixes)
+[FIXED] examples/examp_a.rs (1 fix)
+[FIXED] examples/examp_b.rs (1 fix)
 
 "#]])
         .run();
@@ -626,11 +632,11 @@ resolver = "2"
         .with_stderr_data(str![[r#"
      Checked a v0.1.0 - a (lib)
      Checked b v0.1.0 - b (lib)
+[CHECKING] a v0.1.0
+[CHECKING] b v0.1.0
      Checked a v0.1.0 - a (lib)
      Checked b v0.1.0 - b (lib)
-[CHECKING] a v0.1.0
 [FIXED] a/src/lib.rs (1 fix)
-[CHECKING] b v0.1.0
 [FIXED] b/src/lib.rs (1 fix)
 
 "#]])
@@ -697,24 +703,24 @@ fn fix_order_serial_packages() {
      Checked b v0.1.0 - b (lib)
      Checked c v0.1.0 - c (lib)
      Checked d v0.1.0 - d (lib)
-     Checked a v0.1.0 - a (lib)
-[CHECKING] a v0.1.0
-[FIXED] a/src/lib.rs (1 fix)
-     Checked a v0.1.0 - a (lib)
-     Checked b v0.1.0 - b (lib)
-[CHECKING] b v0.1.0
-[FIXED] b/src/lib.rs (1 fix)
-     Checked a v0.1.0 - a (lib)
-     Checked b v0.1.0 - b (lib)
-     Checked c v0.1.0 - c (lib)
-[CHECKING] c v0.1.0
-[FIXED] c/src/lib.rs (1 fix)
+[CHECKING] d v0.1.0
      Checked a v0.1.0 - a (lib)
      Checked b v0.1.0 - b (lib)
      Checked c v0.1.0 - c (lib)
      Checked d v0.1.0 - d (lib)
-[CHECKING] d v0.1.0
 [FIXED] d/src/lib.rs (1 fix)
+[CHECKING] c v0.1.0
+     Checked a v0.1.0 - a (lib)
+     Checked b v0.1.0 - b (lib)
+     Checked c v0.1.0 - c (lib)
+[FIXED] c/src/lib.rs (1 fix)
+[CHECKING] b v0.1.0
+     Checked a v0.1.0 - a (lib)
+     Checked b v0.1.0 - b (lib)
+[FIXED] b/src/lib.rs (1 fix)
+[CHECKING] a v0.1.0
+     Checked a v0.1.0 - a (lib)
+[FIXED] a/src/lib.rs (1 fix)
 
 "#]])
         .run();
@@ -747,9 +753,10 @@ resolver = "2"
         .with_stderr_data(str![[r#"
      Checked a v0.1.0 - a (lib)
      Checked b v0.1.0 - b (lib)
+[CHECKING] a v0.1.0
+[CHECKING] b v0.1.0
      Checked a v0.1.0 - a (lib)
      Checked b v0.1.0 - b (lib)
-[CHECKING] a v0.1.0
 [FIXED] a/src/lib.rs (1 fix)
 
 "#]])
@@ -828,9 +835,7 @@ a = {{ path = '../a' }}
      Checked b v0.1.0 - b (lib)
      Checked c v0.1.0 - c (lib)
      Checked c v0.1.0 - c (lib)
-     Checked a v0.1.0 - cycle (test)
 [CHECKING] a v0.1.0
-[FIXED] a/tests/cycle.rs (1 fix)
      Checked a v0.1.0 - cycle (test)
      Checked a v0.1.0 - a (lib)
      Checked a v0.1.0 - a (lib)
@@ -839,20 +844,22 @@ a = {{ path = '../a' }}
      Checked c v0.1.0 - c (lib)
      Checked c v0.1.0 - c (lib)
 [FIXED] a/src/lib.rs (1 fix)
+[CHECKING] c v0.1.0
      Checked a v0.1.0 - cycle (test)
      Checked a v0.1.0 - a (lib)
      Checked b v0.1.0 - b (lib)
      Checked b v0.1.0 - b (lib)
+     Checked c v0.1.0 - c (lib)
+     Checked c v0.1.0 - c (lib)
+[FIXED] c/src/lib.rs (1 fix)
 [CHECKING] b v0.1.0
+     Checked a v0.1.0 - cycle (test)
+     Checked a v0.1.0 - a (lib)
+     Checked b v0.1.0 - b (lib)
+     Checked b v0.1.0 - b (lib)
 [FIXED] b/src/lib.rs (1 fix)
      Checked a v0.1.0 - cycle (test)
-     Checked a v0.1.0 - a (lib)
-     Checked b v0.1.0 - b (lib)
-     Checked b v0.1.0 - b (lib)
-     Checked c v0.1.0 - c (lib)
-     Checked c v0.1.0 - c (lib)
-[CHECKING] c v0.1.0
-[FIXED] c/src/lib.rs (1 fix)
+[FIXED] a/tests/cycle.rs (1 fix)
 
 "#]])
         .run();
@@ -896,13 +903,13 @@ shared = {{ path = '../shared' }}
      Checked app v0.1.0 - app (lib)
      Checked shared v0.1.0 - shared (lib)
      Checked shared v0.1.0 - shared (lib)
-[CHECKING] app v0.1.0
+[CHECKING] shared v0.1.0
      Checked app v0.1.0 - build-script-build (custom-build)
      Checked app v0.1.0 - app (lib)
      Checked shared v0.1.0 - shared (lib)
      Checked shared v0.1.0 - shared (lib)
-[CHECKING] shared v0.1.0
 [FIXED] shared/src/lib.rs (1 fix)
+[CHECKING] app v0.1.0
 
 "#]])
         .run();


### PR DESCRIPTION
This is a major re-architecture,
changing from fixing things on a first-reported basis, organized in distinct batches, to tracking a unit
graph and walking up the unit graph, much like how workspace publishing
works.

Side effects:
- units can be built in parallel (see also https://github.com/crate-ci/cargo-fixit/pull/146)
- available units are worked on immediately, rather than batching units (see also https://github.com/crate-ci/cargo-fixit/pull/145)
  - iteration count is now per unit, like `cargo fix`
- clearer where we have various hacks

Regressions
- We show "Checking" for anything we're considering fixing, even if it
  is in the cache
- We aren't properly tracking non-workspace local dependencies or patches-to-local because `cargo  metadata` doesn't report them
- `member -> local -> member` is not scheduled correctly
- We now always run `cargo metaddata --no-deps`
- Likely some algorithmic complexity regressions
- Increases that we'll hit an issue with one unit fixing a file while another only reads it which is currently not detected (see https://github.com/crate-ci/cargo-fixit/pull/146)

This fixes an ordering bug introduced by the message sort added in https://github.com/crate-ci/cargo-fixit/pull/150

Fixes https://github.com/crate-ci/cargo-fixit/issues/52
Closes https://github.com/crate-ci/cargo-fixit/pull/82
Closes https://github.com/crate-ci/cargo-fixit/pull/145
Closes https://github.com/crate-ci/cargo-fixit/pull/146